### PR TITLE
Add documentation for some exported methods

### DIFF
--- a/docs/src/lib/lib.md
+++ b/docs/src/lib/lib.md
@@ -38,7 +38,8 @@ c_proj
 ac_proj
 ac2_proj
 
-expectation_value
+transfer_left
+transfer_right
 ```
 
 ## Algorithms
@@ -85,8 +86,24 @@ VUMPSSvdCut
 SvdCut
 ```
 
-### [Excitations]
+### [Excitations](@id lib_ex_alg)
 ```@docs
 QuasiparticleAnsatz
 FiniteExcited
+```
+
+## Utility
+```@docs
+left_virtualspace
+right_virtualspace
+physicalspace
+add_util_leg
+expectation_value
+variance
+entanglement_spectrum
+entropy
+transfer_spectrum
+correlation_length
+entanglementplot
+transferplot
 ```

--- a/src/operators/sparsempo/sparsempo.jl
+++ b/src/operators/sparsempo/sparsempo.jl
@@ -1,7 +1,8 @@
-"
-    SparseMPO - used to represent both time evolution mpos and hamiltonians
-"
-
+"""
+    struct SparseMPO{S,T<:MPOTensor,E<:Number}
+    
+Sparse MPO, used to represent both time evolution MPOs and hamiltonians.
+"""
 struct SparseMPO{S,T<:MPOTensor,E<:Number} <: AbstractVector{SparseMPOSlice{S,T,E}}
     Os::PeriodicArray{Union{E,T},3}
     domspaces::PeriodicArray{S,2}

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -145,8 +145,8 @@ TensorKit.sectortype(ψtype::Type{<:AbstractMPS}) = sectortype(site_type(ψtype)
 """
     left_virtualspace(ψ::AbstractMPS, i::Int)
     
-Return the left virtual space of the bond tensor at site `i`. This is equivalent to the
-left virtual space of the left-gauged site tensor at site `i + 1`.
+Return the left virtual space of the bond tensor to the right of site `i`. This is
+equivalent to the left virtual space of the left-gauged site tensor at site `i + 1`.
 """
 function left_virtualspace end
 left_virtualspace(A::GenericMPSTensor) = space(A, 1)
@@ -155,8 +155,8 @@ left_virtualspace(O::MPOTensor) = space(O, 1)
 """
     right_virtualspace(ψ::AbstractMPS, i::Int)
 
-Return the right virtual space of the bond tensor at site `i`. This is equivalent to the
-right virtual space of the right-gauged site tensor at site `i`.
+Return the right virtual space of the bond tensor to the right of site `i`. This is
+equivalent to the right virtual space of the right-gauged site tensor at site `i`.
 """
 function right_virtualspace end
 right_virtualspace(A::GenericMPSTensor) = space(A, numind(A))

--- a/src/utility/plotting.jl
+++ b/src/utility/plotting.jl
@@ -1,5 +1,5 @@
 """
-    entanglementplot(state; site=0[, kwargs])
+    entanglementplot(state; site=0[, kwargs...])
 
 Plot the entanglement spectrum of a given InfiniteMPS. 
 
@@ -9,7 +9,7 @@ Plot the entanglement spectrum of a given InfiniteMPS.
 - `sortby=maximum`: the method of sorting the sectors.
 - `sector_margin=1//10`: the amount of whitespace between sectors.
 - `sector_formatter=string`: how to convert sectors to strings.
-- `kwargs...: other kwargs are passed on to the plotting backend.
+- `kwargs...`: other kwargs are passed on to the plotting backend.
 """
 function entanglementplot end
 @userplot EntanglementPlot
@@ -80,10 +80,10 @@ end
 Plot the partial transfer matrix spectrum of two InfiniteMPS's.
 
 # Arguments
-- `above::InfiniteMPS`: above mps for ``transfer_spectrum``.
-- `below::InfiniteMPS`: below mps for ``transfer_spectrum``.
+- `above::InfiniteMPS`: above mps for [`transfer_spectrum`](@ref).
+- `below::InfiniteMPS`: below mps for [`transfer_spectrum`](@ref).
 - `sectors=[]`: vector of sectors for which to compute the spectrum.
-- `transferkwargs`: kwargs for call to ``transfer_spectrum``.
+- `transferkwargs`: kwargs for call to [`transfer_spectrum`](@ref).
 - `kwargs`: other kwargs are passed on to the plotting backend.
 - `thetaorigin=0`: origin of the angle range.
 - `sector_formatter=string`: how to convert sectors to strings.

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -67,6 +67,13 @@ function decompose_localmps(state::AbstractTensorMap{PS,N,1},
     return [A; decompose_localmps(B)]
 end
 
+"""
+    add_util_leg(tensor::AbstractTensorMap{S,N1,N2}) where {S,N1,N2}
+        -> AbstractTensorMap{S,N1+1,N2+1}
+
+Add trivial one-dimensional utility spaces with trivial sector to the left and right of a
+given tensor map, i.e. as the first space of the codomain and the last space of the domain.
+"""
 function add_util_leg(tensor::AbstractTensorMap{S,N1,N2}) where {S,N1,N2}
     ou = oneunit(_firstspace(tensor))
 
@@ -144,7 +151,8 @@ end
 """
     tensorexpr(name::Symbol, ind_out, [ind_in])
 
-Generates expressions for use within [`@tensor`](@ref TensorOperations.@tensor) environments of the form `name[ind_out...; ind_in]`.
+Generates expressions for use within [`@tensor`](@ref TensorOperations.@tensor) environments
+of the form `name[ind_out...; ind_in]`.
 """
 tensorexpr(name::Symbol, inds) = Expr(:ref, name, inds...)
 function tensorexpr(name::Symbol, indout, indin)


### PR DESCRIPTION
Adds some often used (at least I think they are) exported methods to the documentation. I couldn't really think of an ideal place to put them, so I just placed them at the end of the library API documentation for now.

I think just adding them to the docs is strictly better than not, even though for some of them the interface is maybe not ideal at this point.