### PR TITLE
Some `MPOHamiltonian` fixes

### DIFF
--- a/docs/src/man/operators.md
+++ b/docs/src/man/operators.md
@@ -231,7 +231,7 @@ matrix, and the third dimension specifies the column of the matrix.
 
 ```@example operators
 data = Array{Any,3}(missing, 1, 3, 3) # missing is interpreted as zero
-data[1, 1, 1] = identity(ℂ^2)
+data[1, 1, 1] = id(Matrix{ComplexF64}, ℂ^2)
 data[1, 3, 3] = 1 # regular numbers are interpreted as identity operators
 data[1, 1, 2] = -J * S_x
 data[1, 2, 3] = S_x

--- a/docs/src/man/operators.md
+++ b/docs/src/man/operators.md
@@ -132,17 +132,17 @@ end
 
 # horizontal and vertical interactions are easier using Cartesian indices
 horizontal_operators = Dict()
-I_horizontal = CartesianIndex(1, 0)
+I_horizontal = CartesianIndex(0, 1)
 for I in eachindex(IndexCartesian(), square)
-    if I[1] < size(square, 1)
+    if I[2] < size(square, 2)
         horizontal_operators[(I, I + I_horizontal)] = -J * S_x ⊗ S_x
     end
 end
 
 vertical_operators = Dict()
-I_vertical = CartesianIndex(0, 1)
+I_vertical = CartesianIndex(1, 0)
 for I in eachindex(IndexCartesian(), square)
-    if I[2] < size(square, 2)
+    if I[1] < size(square, 1)
         vertical_operators[(I, I + I_vertical)] = -J * S_x ⊗ S_x
     end
 end

--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -121,7 +121,7 @@ function instantiate_operator(lattice::AbstractArray{<:VectorSpace}, (inds′, O
     # convert to linear index type
     operators = mpo.opp
     indices = map(inds) do I
-        return Base._to_linear_index(lattice, I...) # this should mean all inds are valid...
+        return Base._to_linear_index(lattice, Tuple(I)...) # this should mean all inds are valid...
     end
     T = eltype(mpo)
     local_mpo = Union{T,scalartype(T)}[]

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -91,6 +91,20 @@ end
 
     @test convert(TensorMap, H1 * mps) ≈ H1_tm * state
     @test dot(mps, H2, mps) ≈ dot(mps, H2 * mps)
+
+    # test constructor from dictionary with mixed linear and Cartesian lattice indices as keys
+    grid = square = fill(ℂ^2, 3, 3)
+
+    local_operators = Dict((I,) => O₁ for I in eachindex(grid))
+    I_vertical = CartesianIndex(1, 0)
+    vertical_operators = Dict((I, I + I_vertical) => O₂
+                              for I in eachindex(IndexCartesian(), square)
+                              if I[1] < size(square, 1))
+    operators = merge(local_operators, vertical_operators)
+    H4 = MPOHamiltonian(grid, operators)
+
+    @test H4 ≈
+          MPOHamiltonian(grid, local_operators) + MPOHamiltonian(grid, vertical_operators)
 end
 
 @testset "MPOHamiltonian $(sectortype(pspace))" for (pspace, Dspace) in zip(pspaces,


### PR DESCRIPTION
There were two examples in the new `MPOHamiltonian` documentation that failed during the docs build, which are fixed here.

One was just a typo here
https://github.com/QuantumKitHub/MPSKit.jl/blob/965999ad5d5dd808c2802d59a18557db0a44cb53/docs/src/man/operators.md?plain=1#L234
where `identity` should have been `id`. I also had to specify the storage type since it could not convert to `Matrix{ComplexF64}` the default `Matrix{Float64}` here
https://github.com/QuantumKitHub/MPSKit.jl/blob/965999ad5d5dd808c2802d59a18557db0a44cb53/src/operators/sparsempo/sparsempo.jl#L72
which threw
```julia
ERROR: MethodError: Cannot `convert` an object of type 
  TrivialTensorMap{ComplexSpace, 2, 2, Matrix{ComplexF64}} to an object of type 
  Union{Float64, TrivialTensorMap{ComplexSpace, 2, 2, Matrix{Float64}}}
```


The second was an issue with iterating over a `CartesianIndex` here
https://github.com/QuantumKitHub/MPSKit.jl/blob/965999ad5d5dd808c2802d59a18557db0a44cb53/src/operators/mpohamiltonian.jl#L124
which caused this example to fail:
https://github.com/QuantumKitHub/MPSKit.jl/blob/965999ad5d5dd808c2802d59a18557db0a44cb53/docs/src/man/operators.md?plain=1#L124-L153
I just replaced the `I...` with `Tuple(I)...` which fixed the example. This should not break for `I::Tuple{Vararg{Int}}` which is good, but I don't know if there are other allowed types for specifying vertices for which this fix won't work?