### PR TITLE
Fix issue where SVDCut produces InfiniteMPS that is not full rank

### DIFF
--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -83,7 +83,16 @@ function changebonds(ψ::InfiniteMPS, alg::SvdCut)
         copied[i + 1] = _transpose_front(U' * _transpose_tail(copied[i + 1]))
     end
 
-    return normalize!(InfiniteMPS(copied, complex(ncr)))
+    # make sure everything is full rank:
+    makefullrank!(copied)
+
+    # if the bond dimension is not changed, we can keep the same center, otherwise recompute
+    ψ = if space(ncr, 1) != space(copied[1], 1)
+        InfiniteMPS(copied)
+    else
+        InfiniteMPS(copied, complex(ncr))
+    end
+    return normalize!(ψ)
 end
 
 function changebonds(ψ, H, alg::SvdCut, envs=environments(ψ, H))

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -176,6 +176,9 @@ end
 function InfiniteMPS(AL::AbstractVector{<:GenericMPSTensor}, C₀::MPSBondTensor; kwargs...)
     AL = PeriodicArray(copy.(AL))
 
+    all(isfullrank, AL) ||
+        @warn "Constructing an MPS from tensors that are not full rank"
+
     # initialize tensor storage
     AC = similar.(AL)
     AR = similar.(AL)


### PR DESCRIPTION
`changebonds` with `SVDCut` used the `InfiniteMPS(AL, C0)` constructor, and this constructor did not check that all tensors are full rank, or try to correct for it. `InfiniteMPS(AL)` does this, so this fixes the issue.