### PR TITLE
Incorporated an alg argument for GD which can be set to SDD(fast, unstable) or SVD(slow, stable)

### DIFF
--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -146,13 +146,13 @@ end
 """
 Retract a left-canonical MPSMultiline along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:MPSMultiline}, tg, alpha)
+function retract(x::ManifoldPoint{<:MPSMultiline}, tg, alpha; alg = SDD())
     g = reshape(tg, size(x.state))
 
     nal = similar(x.state.AL)
     h = similar(g)
     for (i, cg) in enumerate(tg)
-        (nal[i], th) = Grassmann.retract(x.state.AL[i], cg.Pg, alpha)
+        (nal[i], th) = Grassmann.retract(x.state.AL[i], cg.Pg, alpha; alg = alg)
         h[i] = PrecGrad(th)
     end
 
@@ -165,13 +165,13 @@ end
 """
 Retract a left-canonical infinite MPS along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:InfiniteMPS}, g, alpha)
+function retract(x::ManifoldPoint{<:InfiniteMPS}, g, alpha; alg = SDD())
     state = x.state
     envs = x.envs
     nal = similar(state.AL)
     h = similar(g)  # The tangent at the end-point
     for i in 1:length(g)
-        nal[i], th = Grassmann.retract(state.AL[i], g[i].Pg, alpha)
+        nal[i], th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg = alg)
         h[i] = PrecGrad(th)
     end
 
@@ -185,14 +185,14 @@ end
 """
 Retract a left-canonical finite MPS along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:FiniteMPS}, g, alpha)
+function retract(x::ManifoldPoint{<:FiniteMPS}, g, alpha; alg = SDD())
     state = x.state
     envs = x.envs
 
     y = copy(state)  # The end-point
     h = similar(g)  # The tangent at the end-point
     for i in 1:length(g)
-        yal, th = Grassmann.retract(state.AL[i], g[i].Pg, alpha)
+        yal, th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg = alg)
         h[i] = PrecGrad(th)
         y.AC[i] = (yal, state.CR[i])
     end
@@ -207,10 +207,10 @@ end
 Transport a tangent vector `h` along the retraction from `x` in direction `g` by distance
 `alpha`. `xp` is the end-point of the retraction.
 """
-function transport!(h, x, g, alpha, xp)
+function transport!(h, x, g, alpha, xp; alg = SDD())
     for i in 1:length(h)
         h[i] = PrecGrad(Grassmann.transport!(h[i].Pg, x.state.AL[i], g[i].Pg, alpha,
-                                             xp.state.AL[i]))
+                                             xp.state.AL[i]; alg = alg))
     end
     return h
 end

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -146,13 +146,13 @@ end
 """
 Retract a left-canonical MPSMultiline along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:MPSMultiline}, tg, alpha; alg = SDD())
+function retract(x::ManifoldPoint{<:MPSMultiline}, tg, alpha; alg=SDD())
     g = reshape(tg, size(x.state))
 
     nal = similar(x.state.AL)
     h = similar(g)
     for (i, cg) in enumerate(tg)
-        (nal[i], th) = Grassmann.retract(x.state.AL[i], cg.Pg, alpha; alg = alg)
+        (nal[i], th) = Grassmann.retract(x.state.AL[i], cg.Pg, alpha; alg=alg)
         h[i] = PrecGrad(th)
     end
 
@@ -165,13 +165,13 @@ end
 """
 Retract a left-canonical infinite MPS along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:InfiniteMPS}, g, alpha; alg = SDD())
+function retract(x::ManifoldPoint{<:InfiniteMPS}, g, alpha; alg=SDD())
     state = x.state
     envs = x.envs
     nal = similar(state.AL)
     h = similar(g)  # The tangent at the end-point
     for i in 1:length(g)
-        nal[i], th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg = alg)
+        nal[i], th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg=alg)
         h[i] = PrecGrad(th)
     end
 
@@ -185,14 +185,14 @@ end
 """
 Retract a left-canonical finite MPS along Grassmann tangent `g` by distance `alpha`.
 """
-function retract(x::ManifoldPoint{<:FiniteMPS}, g, alpha; alg = SDD())
+function retract(x::ManifoldPoint{<:FiniteMPS}, g, alpha; alg=SDD())
     state = x.state
     envs = x.envs
 
     y = copy(state)  # The end-point
     h = similar(g)  # The tangent at the end-point
     for i in 1:length(g)
-        yal, th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg = alg)
+        yal, th = Grassmann.retract(state.AL[i], g[i].Pg, alpha; alg=alg)
         h[i] = PrecGrad(th)
         y.AC[i] = (yal, state.CR[i])
     end
@@ -207,10 +207,10 @@ end
 Transport a tangent vector `h` along the retraction from `x` in direction `g` by distance
 `alpha`. `xp` is the end-point of the retraction.
 """
-function transport!(h, x, g, alpha, xp; alg = SDD())
+function transport!(h, x, g, alpha, xp; alg=SDD())
     for i in 1:length(h)
         h[i] = PrecGrad(Grassmann.transport!(h[i].Pg, x.state.AL[i], g[i].Pg, alpha,
-                                             xp.state.AL[i]; alg = alg))
+                                             xp.state.AL[i]; alg=alg))
     end
     return h
 end

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -2,8 +2,8 @@
 # submodule, to keep the MPSKit module namespace cleaner.
 """
 A module for functions related to treating an InfiniteMPS in left-canonical form as a bunch
-of points on Grassmann manifolds, and performing things like retractions and transports
-on these Grassmann manifolds.
+of points on Grassmann manifolds, and performing things like retractions and transports on
+these Grassmann manifolds.
 
 The module exports nothing, and all references to it should be qualified, e.g.
 `GrassmannMPS.fg`.

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -23,8 +23,7 @@ with a preconditioner to induce the metric from the Hilbert space inner product.
 - `maxiter::Int`: maximum amount of iterations
 - `verbosity::Int`: level of information display
 - `alg::OrthogonalFactorizationAlgorithm` : specifies which algorithm is used for singular
-  value decompositions in the retract and transport functions. Choices are SDD() which is faster but
-  less stable and SVD() which is slower but more stable.
+  value decompositions in the retract and transport functions.
 """
 struct GradientGrassmann <: Algorithm
     method::OptimKit.OptimizationAlgorithm

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -30,7 +30,8 @@ struct GradientGrassmann <: Algorithm
     finalize!::Function
     svd_alg::OrthogonalFactorizationAlgorithm
     function GradientGrassmann(; method=ConjugateGradient, (finalize!)=OptimKit._finalize!,
-                               tol=Defaults.tol, maxiter=Defaults.maxiter, verbosity=2, svd_alg=TensorKit.SDD()) 
+                               tol=Defaults.tol, maxiter=Defaults.maxiter, verbosity=2,
+                               svd_alg=TensorKit.SDD())
         if isa(method, OptimKit.OptimizationAlgorithm)
             # We were given an optimisation method, just use it.
             m = method
@@ -56,8 +57,15 @@ function find_groundstate(ψ::S, H, alg::GradientGrassmann,
     x, _, _, _, normgradhistory = optimize(GrassmannMPS.fg,
                                            GrassmannMPS.ManifoldPoint(ψ, envs),
                                            alg.method;
-                                           (transport!)=(Θ, W, Δ, α, W′) -> GrassmannMPS.transport!(Θ, W, Δ, α, W′; alg=alg.svd_alg),
-                                           retract=(W, Δ, α) -> GrassmannMPS.retract(W, Δ, α; alg=alg.svd_alg)                      ,
+                                           (transport!)=(Θ, W, Δ, α, W′) -> GrassmannMPS.transport!(Θ,
+                                                                                                    W,
+                                                                                                    Δ,
+                                                                                                    α,
+                                                                                                    W′;
+                                                                                                    alg=alg.svd_alg),
+                                           retract=(W, Δ, α) -> GrassmannMPS.retract(W, Δ,
+                                                                                     α;
+                                                                                     alg=alg.svd_alg),
                                            inner=GrassmannMPS.inner,
                                            (scale!)=GrassmannMPS.scale!,
                                            (add!)=GrassmannMPS.add!,

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -23,7 +23,7 @@ with a preconditioner to induce the metric from the Hilbert space inner product.
 - `maxiter::Int`: maximum amount of iterations
 - `verbosity::Int`: level of information display
 - `alg::OrthogonalFactorizationAlgorithm` : specifies which algorithm is used for singular
-  value decompositions in the retract and transport functions.
+    value decompositions in the retract and transport functions.
 """
 struct GradientGrassmann <: Algorithm
     method::OptimKit.OptimizationAlgorithm

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -2,7 +2,7 @@
     GradientGrassmann <: Algorithm
 
 Variational gradient-based optimization algorithm that keeps the MPS in left-canonical form,
-as points on a Grassmann manifold. The optimization is then a Riemannian gradient descent 
+as points on a Grassmann manifold. The optimization is then a Riemannian gradient descent
 with a preconditioner to induce the metric from the Hilbert space inner product.
 
 ## Fields
@@ -22,7 +22,9 @@ with a preconditioner to induce the metric from the Hilbert space inner product.
 - `tol::Float64`: tolerance for convergence criterium
 - `maxiter::Int`: maximum amount of iterations
 - `verbosity::Int`: level of information display
-- `alg::OrthogonalFactorizationAlgorithm` : algorithm to perform the orthogonal factorizations during the automatic differentiation
+- `alg::OrthogonalFactorizationAlgorithm` : specifies which algorithm is used for singular
+  value decompositions in the retract and transport functions. Choices are SDD() which is faster but
+  less stable and SVD() which is slower but more stable.
 """
 struct GradientGrassmann <: Algorithm
     method::OptimKit.OptimizationAlgorithm


### PR DESCRIPTION
Together with https://github.com/Jutho/TensorKitManifolds.jl/pull/11 this implements functionality that allows the user to choose which SVD algorithm is being used internally in the gradient descent gradient calculation. 

The options are SDD(fast but potentially unstable) vs SVD(slow but stable).

These two PR should fix the issue : https://github.com/QuantumKitHub/MPSKit.jl/issues/109