### PR TITLE
This PR makes Gradient Descent parallelized using Threads.@spawn

### DIFF
--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -76,9 +76,9 @@ function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
                 al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
             end
         end
-        g = map(CartesianIndices(state.AL)) do I
-            return Threads.@spawn Grassmann.project(al_d[I], state.AL[I])  
-        end .|> fetch
+        g = fetch.(map(CartesianIndices(state.AL)) do I
+                       return Threads.@spawn Grassmann.project(al_d[I], state.AL[I])
+                   end)
     else
         al_d = similar(state.AL)
         for i in 1:length(state)

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -69,7 +69,7 @@ struct ManifoldPoint{T,E,G,C}
 end
 
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
-    g = similar(state.AL)
+    g = Vector{  Grassmann.GrassmannTangent  }(undef, length(state.Al))
     @static if Defaults.parallelize_sites
         @sync for i in 1:length(state)
             Threads.@spawn begin

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -69,7 +69,6 @@ struct ManifoldPoint{T,E,G,C}
 end
 
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
-    g = Vector{  Grassmann.GrassmannTangent  }(undef, length(state.AL))
     @static if Defaults.parallelize_sites
         @sync for i in 1:length(state)
             Threads.@spawn begin
@@ -77,6 +76,9 @@ function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
                 g[i] = Grassmann.project(al_d_i, state.AL[i])
             end
         end
+        g = map(CartesianIndices(state.AL)) do I
+            return Grassmann.project(al_d[I], state.AL[I])  
+        end 
     else
         al_d = similar(state.AL)
         for i in 1:length(state)
@@ -103,8 +105,8 @@ function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
 end
 
 function ManifoldPoint(state::MPSMultiline, envs)
-    #TODO : support parralelize_sites
     # FIXME: add support for unitcells
+    # TODO : then support parralelize_sites
     @assert length(state.AL) == 1 "GradientGrassmann only supports MPSMultiline without unitcells for now"
 
     # TODO: this really should not use the operator from the environment

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -69,19 +69,21 @@ struct ManifoldPoint{T,E,G,C}
 end
 
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
-    al_d = similar(state.AL)
+    g = similar(state.AL)
     @static if Defaults.parallelize_sites
         @sync for i in 1:length(state)
             Threads.@spawn begin
-                al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
+                al_d_i = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
+                g[i] = Grassmann.project(al_d_i, state.AL[i])
             end
         end
     else
+        al_d = similar(state.AL)
         for i in 1:length(state)
             al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
         end
+        g = Grassmann.project.(al_d, state.AL)
     end
-    g = Grassmann.project.(al_d, state.AL)
 
     Rhoreg = Vector{eltype(state.CR)}(undef, length(state))
     δmin = sqrt(eps(real(scalartype(state))))

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -70,10 +70,10 @@ end
 
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
     @static if Defaults.parallelize_sites
+        al_d = similar(state.AL)
         @sync for i in 1:length(state)
             Threads.@spawn begin
-                al_d_i = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
-                g[i] = Grassmann.project(al_d_i, state.AL[i])
+                al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
             end
         end
         g = map(CartesianIndices(state.AL)) do I

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -71,7 +71,7 @@ end
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
     al_d = similar(state.AL)
     @static if Defaults.parallelize_sites
-        g = fill(nothing, length(state))  #not typstable but this won't be a performance issue for now :) 
+        g = Array{Any}(undef, length(state))  #not typstable but this won't be a performance issue for now :) 
         @sync for i in 1:length(state)
             Threads.@spawn begin
                 al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -69,7 +69,7 @@ struct ManifoldPoint{T,E,G,C}
 end
 
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
-    g = Vector{  Grassmann.GrassmannTangent  }(undef, length(state.Al))
+    g = Vector{  Grassmann.GrassmannTangent  }(undef, length(state.AL))
     @static if Defaults.parallelize_sites
         @sync for i in 1:length(state)
             Threads.@spawn begin

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -77,8 +77,8 @@ function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
             end
         end
         g = map(CartesianIndices(state.AL)) do I
-            return Grassmann.project(al_d[I], state.AL[I])  
-        end 
+            return Threads.@spawn Grassmann.project(al_d[I], state.AL[I])  
+        end .|> fetch
     else
         al_d = similar(state.AL)
         for i in 1:length(state)

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -71,19 +71,17 @@ end
 function ManifoldPoint(state::Union{InfiniteMPS,FiniteMPS}, envs)
     al_d = similar(state.AL)
     @static if Defaults.parallelize_sites
-        g = Array{Any}(undef, length(state))  #not typstable but this won't be a performance issue for now :) 
         @sync for i in 1:length(state)
             Threads.@spawn begin
                 al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
-                g[i] = Grassmann.project(al_d[i], state.AL[i])
             end
         end
     else
         for i in 1:length(state)
             al_d[i] = MPSKit.∂∂AC(i, state, envs.opp, envs) * state.AC[i]
         end
-        g = Grassmann.project.(al_d, state.AL)
     end
+    g = Grassmann.project.(al_d, state.AL)
 
     Rhoreg = Vector{eltype(state.CR)}(undef, length(state))
     δmin = sqrt(eps(real(scalartype(state))))


### PR DESCRIPTION
As the title suggest this PR makes Gradient descent parallel...

Two remarks are : 
1) I failed to parallelize : 
```julia
function retract(x::ManifoldPoint{<:FiniteMPS}, g, alpha)
    #TODO : support parralelize_sites.
    state = x.state
    envs = x.envs

    y = copy(state)  # The end-point
    h = similar(g)  # The tangent at the end-point
    for i in 1:length(g)
        yal, th = Grassmann.retract(state.AL[i], g[i].Pg, alpha)
        h[i] = PrecGrad(th)
        y.AC[i] = (yal, state.CR[i])
    end
    normalize!(y)

    n_y = ManifoldPoint(y, envs)

    return n_y, h
end
```

2) the tests currently don't consider n-site unit cells. To cure this I'll make some new tests in another PR which do 3 site unit cells.