### PR TITLE
update normalization convention environments

### DIFF
--- a/src/environments/permpoinfenv.jl
+++ b/src/environments/permpoinfenv.jl
@@ -180,8 +180,7 @@ function mixed_fixpoints(above::MPSMultiline, mpo::MPOMultiline, below::MPSMulti
         for col in 1:numcols
             λ = dot(CRs_bot[col],
                     MPO_∂∂C(GLs[row, col + 1], GRs[row, col]) * CRs_top[col])
-            scale!(GLs[row, col + 1], 1 / sqrt(λ))
-            scale!(GRs[row, col], 1 / sqrt(λ))
+            scale!(GLs[row, col + 1], inv(λ))
         end
     end
 


### PR DESCRIPTION
This changes the normalization convention of the environments to no longer "divide the norm" between left and right, but simply absorb it on the left side. This ensures better compatibility with real states/operators.

Closes #198 .
