### PR TITLE
[Bugfix] Ensure that projection environments have correct `above`

### DIFF
--- a/src/environments/FinEnv.jl
+++ b/src/environments/FinEnv.jl
@@ -73,9 +73,10 @@ function MPSKit.environments(below::FiniteMPS{S}, O::DenseMPO, above=nothing) wh
     N = length(below)
     leftstart = isomorphism(storagetype(S),
                             left_virtualspace(below, 0) ⊗ space(O[1], 1)' ←
-                            left_virtualspace(below, 0))
+                            left_virtualspace(something(above, below), 0))
     rightstart = isomorphism(storagetype(S),
-                             right_virtualspace(below, N) ⊗ space(O[N], 4)' ←
+                             right_virtualspace(something(above, below), N) ⊗
+                             space(O[N], 4)' ←
                              right_virtualspace(below, length(below)))
     return environments(below, O, above, leftstart, rightstart)
 end
@@ -101,7 +102,7 @@ end
 function environments(state::Union{FiniteMPS,WindowMPS}, opp::ProjectionOperator)
     @plansor leftstart[-1; -2 -3 -4] := l_LL(opp.ket)[-3; -4] * l_LL(opp.ket)[-1; -2]
     @plansor rightstart[-1; -2 -3 -4] := r_RR(opp.ket)[-1; -2] * r_RR(opp.ket)[-3; -4]
-    return environments(state, fill(nothing, length(state)), state, leftstart, rightstart)
+    return environments(state, fill(nothing, length(state)), opp.ket, leftstart, rightstart)
 end
 
 #notify the cache that we updated in-place, so it should invalidate the dependencies

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -426,16 +426,16 @@ end
             ψ = FiniteMPS(rand, ComplexF64, len, ℙ^2, ℙ^15)
             (ψ, envs, _) = find_groundstate(ψ, H; verbosity)
 
-            #find energy with quasiparticle ansatz
+            # find energy with quasiparticle ansatz
             energies_QP, ϕs = excitations(H, QuasiparticleAnsatz(), ψ, envs)
             @test variance(ϕs[1], H) < 1e-6
 
-            #find energy with normal dmrg
-            energies_dm, _ = excitations(H,
-                                         FiniteExcited(;
-                                                       gsalg=DMRG(; verbosity,
-                                                                  tol=1e-6)), ψ)
-            @test energies_dm[1] ≈ energies_QP[1] + expectation_value(ψ, H, envs) atol = 1e-4
+            # find energy with normal dmrg
+            for gsalg in (DMRG(; verbosity, tol=1e-6),
+                          DMRG2(; verbosity, tol=1e-6, trscheme=truncbelow(1e-4)))
+                energies_dm, _ = excitations(H, FiniteExcited(; gsalg), ψ)
+                @test energies_dm[1] ≈ energies_QP[1] + expectation_value(ψ, H, envs) atol = 1e-4
+            end
 
             # find energy with Chepiga ansatz
             energies_ch, _ = excitations(H, ChepigaAnsatz(), ψ, envs)


### PR DESCRIPTION
This fixes an issue where the environments for projection operators did not get the correct state in their `above` field, hence giving space mismatches and (likely) wrong results before.

Closes #203