### PR TITLE
update `left` and `right_virtualspace`

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -60,8 +60,6 @@ export exact_diagonalization
 export TransferMatrix
 export transfer_left, transfer_right
 
-@deprecate virtualspace left_virtualspace # there is a possible ambiguity when C isn't square, necessitating specifying left or right virtualspace
-
 # Abstract type defs
 abstract type Algorithm end
 

--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -66,8 +66,8 @@ function expectation_value(ψ::AbstractMPS, (inds, O)::Pair)
         # left side
         T = storagetype(site_type(ψ))
         @plansor Vl[-1 -2; -3] := isomorphism(T,
-                                              left_virtualspace(ψ, sites[1] - 1),
-                                              left_virtualspace(ψ, sites[1] - 1))[-1; -3] *
+                                              left_virtualspace(ψ, sites[1]),
+                                              left_virtualspace(ψ, sites[1]))[-1; -3] *
                                   conj(Ut[-2])
 
         # middle
@@ -104,7 +104,7 @@ function expectation_value(ψ::InfiniteMPS, H::InfiniteMPOHamiltonian,
                            envs::AbstractMPSEnvironments=environments(ψ, H))
     return sum(1:length(ψ)) do i
         util = fill_data!(similar(ψ.AL[1], right_virtualspace(H, i)[end]), one)
-        @plansor GR[-1 -2; -3] := r_LL(ψ, i)[-1; -3] * conj(util[-2])
+        @plansor GR[-1 -2; -3] := r_LL(ψ, i)[-1; -3] * util[-2]
         return contract_mpo_expval(ψ.AL[i], leftenv(envs, i, ψ), H[i][:, 1, 1, end], GR)
     end
 end

--- a/src/algorithms/fidelity_susceptibility.jl
+++ b/src/algorithms/fidelity_susceptibility.jl
@@ -11,7 +11,7 @@ function fidelity_susceptibility(state::Union{FiniteMPS,InfiniteMPS}, H₀::T,
         Tos = LeftGaugedQP(rand, state)
         for (i, ac) in enumerate(state.AC)
             temp = ∂∂AC(i, state, V, venvs) * ac
-            help = fill_data!(similar(ac, utilleg(Tos)), one)
+            help = fill_data!(similar(ac, auxiliaryspace(Tos)), one)
             @plansor Tos[i][-1 -2; -3 -4] := temp[-1 -2; -4] * help[-3]
         end
 

--- a/src/algorithms/timestep/timeevmpo.jl
+++ b/src/algorithms/timestep/timeevmpo.jl
@@ -327,7 +327,7 @@ function make_time_mpo(H::InfiniteMPOHamiltonian{T}, dt, alg::WII) where {T}
         Vᵣ = right_virtualspace(H, i)[1:(end - 1)]
         P = physicalspace(H, i)
 
-        h′ = similar(H[i], Vₗ ⊗ P ← P ⊗ Vᵣ')
+        h′ = similar(H[i], Vₗ ⊗ P ← P ⊗ Vᵣ)
         h′[2:end, 1, 1, 2:end] = WA[i]
         h′[2:end, 1, 1, 1] = WB[i]
         h′[1, 1, 1, 2:end] = WC[i]

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -63,10 +63,10 @@ domain of each eigenvector. The `tol` and `num_vals` keyword arguments are passe
 """
 function transfer_spectrum(above::InfiniteMPS; below=above, tol=Defaults.tol, num_vals=20,
                            sector=first(sectors(oneunit(left_virtualspace(above, 1)))))
-    init = randomize!(similar(above.AL[1], left_virtualspace(below, 0),
-                              ℂ[typeof(sector)](sector => 1)' * left_virtualspace(above, 0)))
+    init = randomize!(similar(above.AL[1], left_virtualspace(below, 1),
+                              ℂ[typeof(sector)](sector => 1)' * left_virtualspace(above, 1)))
 
-    transferspace = fuse(left_virtualspace(above, 0) * left_virtualspace(below, 0)')
+    transferspace = fuse(left_virtualspace(above, 1) * left_virtualspace(below, 1)')
     num_vals = min(dim(transferspace, sector), num_vals) # we can ask at most this many values
     eigenvals, eigenvecs, convhist = eigsolve(flip(TransferMatrix(above.AL, below.AL)),
                                               init, num_vals, :LM; tol=tol)
@@ -239,26 +239,26 @@ function periodic_boundary_conditions(mpo::InfiniteMPO{O},
 
     # allocate output
     output = Vector{O}(undef, L)
-    V_wrap = left_virtualspace(mpo, 1)'
+    V_wrap = left_virtualspace(mpo, 1)
     ST = storagetype(O)
 
     util = fill!(similar(mpo[1], oneunit(V_wrap)), one(scalartype(O)))
-    @plansor cup[-1; -2 -3] := id(ST, V_wrap)[-3; -2] * util[-1]
+    @plansor cup[-1; -2 -3] := id(ST, V_wrap)[-2; -3] * util[-1]
 
     local F_right
     for i in 1:L
         V_left = i == 1 ? oneunit(V_wrap) : fuse(V_wrap ⊗ left_virtualspace(mpo, i))
-        V_right = i == L ? oneunit(V_wrap) : fuse(V_wrap' ⊗ right_virtualspace(mpo, i)')
+        V_right = i == L ? oneunit(V_wrap) : fuse(V_wrap ⊗ right_virtualspace(mpo, i))
         output[i] = similar(mpo[i],
                             V_left * physicalspace(mpo, i) ←
                             physicalspace(mpo, i) * V_right)
         F_left = i == 1 ? cup : F_right
         F_right = i == L ? cup :
-                  isomorphism(ST, V_right ← V_wrap * right_virtualspace(mpo, i)')
-        @plansor output[i][-1 -2; -3 -4] = F_left[-1; 1 2] *
-                                           τ[-3 1; 4 3] *
-                                           mpo[i][2 -2; 3 5] *
-                                           conj(F_right[-4; 4 5])
+                  isomorphism(ST, V_right ← V_wrap' * right_virtualspace(mpo, i))
+        @plansor contractcheck = true output[i][-1 -2; -3 -4] = F_left[-1; 1 2] *
+                                                                τ[-3 1; 4 3] *
+                                                                mpo[i][2 -2; 3 5] *
+                                                                conj(F_right[-4; 4 5])
     end
 
     mpo isa SparseMPO && dropzeros!.(output) # the above process fills sparse mpos with zeros.

--- a/src/environments/abstract_envs.jl
+++ b/src/environments/abstract_envs.jl
@@ -14,12 +14,10 @@ Base.unlock(envs::AbstractMPSEnvironments) = unlock(envs.lock);
 # Allocating tensors
 # ------------------
 
-# TODO: fix the fucking left/right virtualspace bullshit
-# TODO: storagetype stuff
 function allocate_GL(bra::AbstractMPS, mpo::AbstractMPO, ket::AbstractMPS, i::Int)
     T = Base.promote_type(scalartype(bra), scalartype(mpo), scalartype(ket))
-    V = left_virtualspace(bra, i - 1) ⊗ left_virtualspace(mpo, i)' ←
-        left_virtualspace(ket, i - 1)
+    V = left_virtualspace(bra, i) ⊗ left_virtualspace(mpo, i)' ←
+        left_virtualspace(ket, i)
     if V isa BlockTensorKit.TensorMapSumSpace
         TT = blocktensormaptype(spacetype(bra), numout(V), numin(V), T)
     else
@@ -30,7 +28,7 @@ end
 
 function allocate_GR(bra::AbstractMPS, mpo::AbstractMPO, ket::AbstractMPS, i::Int)
     T = Base.promote_type(scalartype(bra), scalartype(mpo), scalartype(ket))
-    V = right_virtualspace(ket, i) ⊗ right_virtualspace(mpo, i)' ←
+    V = right_virtualspace(ket, i) ⊗ right_virtualspace(mpo, i) ←
         right_virtualspace(bra, i)
     if V isa BlockTensorKit.TensorMapSumSpace
         TT = blocktensormaptype(spacetype(bra), numout(V), numin(V), T)
@@ -42,8 +40,8 @@ end
 
 function allocate_GBL(bra::QP, mpo::AbstractMPO, ket::QP, i::Int)
     T = Base.promote_type(scalartype(bra), scalartype(mpo), scalartype(ket))
-    V = left_virtualspace(bra.left_gs, i - 1) ⊗ left_virtualspace(mpo, i)' ←
-        auxiliaryspace(ket)' ⊗ left_virtualspace(ket.left_gs, i - 1)
+    V = left_virtualspace(bra, i) ⊗ left_virtualspace(mpo, i)' ←
+        auxiliaryspace(ket)' ⊗ left_virtualspace(ket, i)
     if V isa BlockTensorKit.TensorMapSumSpace
         TT = blocktensormaptype(spacetype(bra), numout(V), numin(V), T)
     else
@@ -54,8 +52,8 @@ end
 
 function allocate_GBR(bra::QP, mpo::AbstractMPO, ket::QP, i::Int)
     T = Base.promote_type(scalartype(bra), scalartype(mpo), scalartype(ket))
-    V = right_virtualspace(ket.right_gs, i) ⊗ right_virtualspace(mpo, i)' ←
-        auxiliaryspace(ket)' ⊗ right_virtualspace(bra.right_gs, i)
+    V = right_virtualspace(ket, i) ⊗ right_virtualspace(mpo, i) ←
+        auxiliaryspace(ket)' ⊗ right_virtualspace(bra, i)
     if V isa BlockTensorKit.TensorMapSumSpace
         TT = blocktensormaptype(spacetype(bra), numout(V), numin(V), T)
     else

--- a/src/environments/finite_envs.jl
+++ b/src/environments/finite_envs.jl
@@ -34,30 +34,18 @@ function environments(below, operator, above, leftstart, rightstart)
                               rightenvs)
 end
 
-function environments(below::FiniteMPS{S}, O::DenseMPO, above=nothing) where {S}
-    N = length(below)
-    leftstart = isomorphism(storagetype(S),
-                            left_virtualspace(below, 0) ⊗ space(O[1], 1)' ←
-                            left_virtualspace(something(above, below), 0))
-    rightstart = isomorphism(storagetype(S),
-                             right_virtualspace(something(above, below), N) ⊗
-                             space(O[N], 4)' ←
-                             right_virtualspace(below, length(below)))
-    return environments(below, O, above, leftstart, rightstart)
-end
-
 function environments(below::FiniteMPS{S}, O::Union{FiniteMPO,FiniteMPOHamiltonian},
                       above=nothing) where {S}
-    Vl_bot = left_virtualspace(below, 0)
+    Vl_bot = left_virtualspace(below, 1)
     Vl_mid = left_virtualspace(O, 1)
-    Vl_top = isnothing(above) ? left_virtualspace(below, 0) : left_virtualspace(above, 0)
+    Vl_top = isnothing(above) ? left_virtualspace(below, 1) : left_virtualspace(above, 1)
     leftstart = isomorphism(storagetype(S), Vl_bot ⊗ Vl_mid' ← Vl_top)
 
     N = length(below)
     Vr_bot = right_virtualspace(below, N)
     Vr_mid = right_virtualspace(O, N)
     Vr_top = isnothing(above) ? right_virtualspace(below, N) : right_virtualspace(above, N)
-    rightstart = isomorphism(storagetype(S), Vr_top ⊗ Vr_mid' ← Vr_bot)
+    rightstart = isomorphism(storagetype(S), Vr_top ⊗ Vr_mid ← Vr_bot)
 
     return environments(below, O, above, leftstart, rightstart)
 end

--- a/src/operators/abstractmpo.jl
+++ b/src/operators/abstractmpo.jl
@@ -156,7 +156,7 @@ Compute the mpo tensor that arises from multiplying MPOs.
 function fuse_mul_mpo(O1::MPOTensor, O2::MPOTensor)
     T = promote_type(scalartype(O1), scalartype(O2))
     F_left = fuser(T, left_virtualspace(O2), left_virtualspace(O1))
-    F_right = fuser(T, right_virtualspace(O2)', right_virtualspace(O1)')
+    F_right = fuser(T, right_virtualspace(O2), right_virtualspace(O1))
     @plansor O[-1 -2; -3 -4] := F_left[-1; 1 2] *
                                 O2[1 5; -3 3] *
                                 O1[2 -2; 5 4] *
@@ -203,7 +203,7 @@ function add_physical_charge(O::BraidingTensor, charge::Sector)
     sectortype(O) === typeof(charge) || throw(SectorMismatch())
     auxspace = Vect[typeof(charge)](charge => 1)
     V = left_virtualspace(O) ⊗ fuse(physicalspace(O), auxspace) ←
-        fuse(physicalspace(O), auxspace) ⊗ right_virtualspace(O)'
+        fuse(physicalspace(O), auxspace) ⊗ right_virtualspace(O)
     return BraidingTensor{scalartype(O)}(V)
 end
 function add_physical_charge(O::AbstractBlockTensorMap{<:Any,<:Any,2,2}, charge::Sector)
@@ -213,7 +213,7 @@ function add_physical_charge(O::AbstractBlockTensorMap{<:Any,<:Any,2,2}, charge:
 
     Odst = similar(O,
                    left_virtualspace(O) ⊗ fuse(physicalspace(O), auxspace) ←
-                   fuse(physicalspace(O), auxspace) ⊗ right_virtualspace(O)')
+                   fuse(physicalspace(O), auxspace) ⊗ right_virtualspace(O))
     for (I, v) in nonzero_pairs(O)
         Odst[I] = add_physical_charge(v, charge)
     end

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -156,34 +156,38 @@ TensorKit.sectortype(ψ::AbstractMPS) = sectortype(typeof(ψ))
 TensorKit.sectortype(ψtype::Type{<:AbstractMPS}) = sectortype(site_type(ψtype))
 
 """
-    left_virtualspace(ψ::AbstractMPS, i::Int)
+    left_virtualspace(ψ::AbstractMPS, [pos=1:length(ψ)])
     
-Return the left virtual space of the bond tensor to the right of site `i`. This is
-equivalent to the left virtual space of the left-gauged site tensor at site `i + 1`.
+Return the virtual space of the bond to the left of sites `pos`.
+
+!!! warning
+    In rare cases, the gauge tensor on the virtual space might not be square, and as a result it
+    cannot always be guaranteed that `right_virtualspace(ψ, i - 1) == left_virtualspace(ψ, i)`
 """
 function left_virtualspace end
 left_virtualspace(A::GenericMPSTensor) = space(A, 1)
 left_virtualspace(O::MPOTensor) = space(O, 1)
 
 """
-    right_virtualspace(ψ::AbstractMPS, i::Int)
+    right_virtualspace(ψ::AbstractMPS, [pos=1:length(ψ)])
 
-Return the right virtual space of the bond tensor to the right of site `i`. This is
-equivalent to the right virtual space of the right-gauged site tensor at site `i`.
+Return the virtual space of the bond to the right of site(s) `pos`.
+
+!!! warning
+    In rare cases, the gauge tensor on the virtual space might not be square, and as a result it
+    cannot always be guaranteed that `right_virtualspace(ψ, i - 1) == left_virtualspace(ψ, i)`
 """
 function right_virtualspace end
-right_virtualspace(A::GenericMPSTensor) = space(A, numind(A))
-right_virtualspace(O::MPOTensor) = space(O, 4)
+right_virtualspace(A::GenericMPSTensor) = space(A, numind(A))'
+right_virtualspace(O::MPOTensor) = space(O, 4)'
 
 """
-    physicalspace(ψ::AbstractMPS, i::Int)
+    physicalspace(ψ::AbstractMPS, [pos=1:length(ψ)])
 
 Return the physical space of the site tensor at site `i`.
 """
 function physicalspace end
+physicalspace(A::MPSTensor) = space(A, 2)
 physicalspace(A::GenericMPSTensor) = prod(x -> space(A, x), 2:(numind(A) - 1))
-function physicalspace(O::MPOTensor)
-    pspace = space(O, 2)
-    # Disallow SumSpace in physical space
-    return pspace isa SumSpace ? only(pspace) : pspace
-end
+physicalspace(O::MPOTensor) = space(O, 2)
+physicalspace(O::AbstractBlockTensorMap{<:Any,<:Any,2,2}) = only(space(O, 2))

--- a/src/states/windowmps.jl
+++ b/src/states/windowmps.jl
@@ -43,7 +43,7 @@ struct WindowMPS{A<:GenericMPSTensor,B<:MPSBondTensor} <: AbstractFiniteMPS
     function WindowMPS(ψₗ::InfiniteMPS{A,B}, ψₘ::FiniteMPS{A,B},
                        ψᵣ::InfiniteMPS{A,B}=copy(ψₗ)) where {A<:GenericMPSTensor,
                                                              B<:MPSBondTensor}
-        left_virtualspace(ψₗ, 0) == left_virtualspace(ψₘ, 0) &&
+        left_virtualspace(ψₗ, 1) == left_virtualspace(ψₘ, 1) &&
             right_virtualspace(ψₘ, length(ψₘ)) == right_virtualspace(ψᵣ, length(ψₘ)) ||
             throw(SpaceMismatch("Mismatch between window and environment virtual spaces"))
         return new{A,B}(ψₗ, ψₘ, ψᵣ)
@@ -62,7 +62,7 @@ end
 function WindowMPS(f, elt, physspaces::Vector{<:Union{S,CompositeSpace{S}}},
                    maxvirtspace::S, ψₗ::InfiniteMPS,
                    ψᵣ::InfiniteMPS=ψₗ) where {S<:ElementarySpace}
-    ψₘ = FiniteMPS(f, elt, physspaces, maxvirtspace; left=left_virtualspace(ψₗ, 0),
+    ψₘ = FiniteMPS(f, elt, physspaces, maxvirtspace; left=left_virtualspace(ψₗ, 1),
                    right=right_virtualspace(ψᵣ, length(physspaces)))
     return WindowMPS(ψₗ, ψₘ, ψᵣ)
 end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -175,6 +175,6 @@ function check_length(a, b...)
     return L
 end
 
-function fuser(::Type{T}, V1::S, V2::S) where {T<:Number,S<:IndexSpace}
-    return isomorphism(Vector{T}, fuse(V1 ⊗ V2), V1 ⊗ V2)
+function fuser(::Type{T}, V1::S, V2::S) where {T,S<:IndexSpace}
+    return isomorphism(T, fuse(V1 ⊗ V2), V1 ⊗ V2)
 end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -561,7 +561,7 @@ end
 
         state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-        @test dim(left_virtualspace(state_tr, 5)) < dim(right_virtualspace(state_oe, 5))
+        @test dim(left_virtualspace(state_tr, 5)) < dim(left_virtualspace(state_oe, 5))
     end
 
     @testset "MPSMultiline" begin
@@ -583,7 +583,7 @@ end
 
         state_tr = changebonds(state_oe, SvdCut(; trscheme=truncdim(dim(Dspace))))
 
-        @test dim(right_virtualspace(state_tr, 1, 1)) <
+        @test dim(left_virtualspace(state_tr, 1, 1)) <
               dim(left_virtualspace(state_oe, 1, 1))
     end
 end


### PR DESCRIPTION
This is a fix of the long-standing issue #103, which rewrites the package to consistently use `left_virtualspace` to denote the space to the left of a lattice site, and `right_virtualspace` to denote the space to the right of a lattice site. Additionally, they are both returned "non-dualised", i.e. `left_virtualspace(mps, i + 1) == right_virtualspace(mps, i)`.

This is obviously very breaking, but should be more consistent in the future.