### PR TITLE
make `tol` a kwarg in `remove_orphans!(::FiniteMPO)`

### DIFF
--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -81,7 +81,7 @@ function remove_orphans!(mpo::InfiniteMPO; tol=eps(real(scalartype(mpo)))^(3 / 4
     return mpo
 end
 
-function remove_orphans!(mpo::FiniteMPO, tol=eps(real(scalartype(mpo)))^(3 / 4))
+function remove_orphans!(mpo::FiniteMPO; tol=eps(real(scalartype(mpo)))^(3 / 4))
     droptol!.(mpo, tol)
 
     # Forward sweep


### PR DESCRIPTION
`tol` was a kwarg in `remove_orphans!` for `InfiniteMPO`s and a regular argument with a default value in `remove_orphans!` for `FiniteMPO`s. This PR unifies the calling signature of the two methods.