### PR TITLE
Set default `tol_max` in gauging eigsolver

### DIFF
--- a/src/states/ortho.jl
+++ b/src/states/ortho.jl
@@ -2,7 +2,7 @@
 # ----------
 
 const _GAUGE_ALG_EIGSOLVE = DynamicTol(Arnoldi(; krylovdim=30, eager=true),
-                                       Defaults.tolgauge / 10, Inf, 1)
+                                       Defaults.tolgauge / 10, Defaults.tol_max, 1)
 
 """
     struct LeftCanonical <: Algorithm


### PR DESCRIPTION
Sets the default maximal tolerance in the solver used in the gauging eigsolve steps. I was having stability issues, where for a slowly converging orthogonalization the eigsolve step used a tolerance so high that it was messing up convergence altogether since the error kept increasing after each inaccurate eigsolve.

I don't have a minimal working example, but I think restricting the `tol_max` here can't hurt either way. Setting it at `Inf` seems a bit dangerous...