### PR TITLE
Fix typo in `IDMRG` struct

### DIFF
--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -15,7 +15,7 @@ $(TYPEDFIELDS)
     maxiter::Int = Defaults.maxiter
 
     "setting for how much information is displayed"
-    verbosity::Int = Defualts.verbosity
+    verbosity::Int = Defaults.verbosity
 
     "algorithm used for gauging the MPS"
     alg_gauge = Defaults.alg_gauge()


### PR DESCRIPTION
Defaults was spelled as Defualts in the `IDMRG` groundstate struct