### PR TITLE
Fix `MPOHamiltonian` constructors for adding multiple terms on the same site

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPSKit"
 uuid = "bb1c41ca-d63c-52ed-829e-0820dda26502"
 authors = "Lukas Devos, Maarten Van Damme and contributors"
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -177,7 +177,7 @@ function FiniteMPOHamiltonian(lattice::AbstractArray{<:VectorSpace},
         # Fill it
         for ((key_L, key_R), o) in zip(nonzero_keys[site], nonzero_opps[site])
             key_R′ = key_R == 0 ? length(virtualspaces[site + 1]) : key_R
-            O[key_L, 1, 1, key_R′] = if o isa Number
+            O[key_L, 1, 1, key_R′] += if o isa Number
                 iszero(o) && continue
                 τ = BraidingTensor{E}(eachspace(O)[key_L, 1, 1, key_R′])
                 isone(o) ? τ : τ * o
@@ -295,7 +295,7 @@ function InfiniteMPOHamiltonian(lattice′::AbstractArray{<:VectorSpace},
         # Fill it
         for ((key_L, key_R′), o) in zip(nonzero_keys[site], nonzero_opps[site])
             key_R = key_R′ == 0 ? length(virtualspaces[site]) : key_R′
-            O[key_L, 1, 1, key_R] = if o isa Number
+            O[key_L, 1, 1, key_R] += if o isa Number
                 iszero(o) && continue
                 τ = BraidingTensor{E}(eachspace(O)[key_L, 1, 1, key_R])
                 isone(o) ? τ : τ * o

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -82,6 +82,15 @@ end
     @test convert(TensorMap, H3) ≈
           O₁ ⊗ E ⊗ E + E ⊗ O₂ + permute(O₂ ⊗ E, ((1, 3, 2), (4, 6, 5)))
 
+    # check if adding terms on the same site works
+    single_terms = Iterators.flatten(Iterators.repeated((i => O₁ / 2 for i in 1:L), 2))
+    H4 = FiniteMPOHamiltonian(lattice, single_terms)
+    @test H4 ≈ H1
+    double_terms = Iterators.flatten(Iterators.repeated(((i, i + 1) => O₂ / 2
+                                                         for i in 1:(L - 1)), 2))
+    H5 = FiniteMPOHamiltonian(lattice, double_terms)
+    @test H5 ≈ H2
+
     # test linear algebra
     @test H1 ≈
           FiniteMPOHamiltonian(lattice, 1 => O₁) +

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -85,11 +85,11 @@ end
     # check if adding terms on the same site works
     single_terms = Iterators.flatten(Iterators.repeated((i => O₁ / 2 for i in 1:L), 2))
     H4 = FiniteMPOHamiltonian(lattice, single_terms)
-    @test H4 ≈ H1
+    @test H4 ≈ H1 atol = 1e-6
     double_terms = Iterators.flatten(Iterators.repeated(((i, i + 1) => O₂ / 2
                                                          for i in 1:(L - 1)), 2))
     H5 = FiniteMPOHamiltonian(lattice, double_terms)
-    @test H5 ≈ H2
+    @test H5 ≈ H2 atol = 1e-6
 
     # test linear algebra
     @test H1 ≈


### PR DESCRIPTION
This fixes an issue where operators that had repeating terms were wrongly discarded:
```julia
H = FiniteMPOHamiltonian(fill(ComplexSpace(2), 2), 1 => O1, 1 => O2)
```
would previously overwrite `O1` with `O2` instead of adding the two.

First caught in https://github.com/QuantumKitHub/MPSKitModels.jl/issues/43