### PR TITLE
Relax MPO element type restrictions

### DIFF
--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -278,9 +278,7 @@ function Base.:*(mpo1::InfiniteMPO, mpo2::InfiniteMPO)
     T = promote_type(scalartype(mpo1), scalartype(mpo2))
     make_fuser(i) = fuser(T, left_virtualspace(mpo2, i), left_virtualspace(mpo1, i))
 
-    Os = map(zip(parent(mpo1), parent(mpo2))) do (O1, O2)
-        return fuse_mul_mpo(O1, O2)
-    end
+    Os = map(fuse_mul_mpo, parent(mpo1), parent(mpo2))
     return InfiniteMPO(Os)
 end
 

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -207,6 +207,7 @@ function VectorInterface.scale!(mpo::MPO, α::Number)
     return mpo
 end
 
+# TODO: merge implementation with that of InfiniteMPO
 function Base.:*(mpo1::FiniteMPO{TO}, mpo2::FiniteMPO{TO}) where {TO<:MPOTensor}
     (N = length(mpo1)) == length(mpo2) || throw(ArgumentError("dimension mismatch"))
     S = spacetype(TO)
@@ -273,11 +274,7 @@ function _fuse_mpo_mps(O::MPOTensor, A::MPSTensor, Fₗ, Fᵣ)
 end
 
 function Base.:*(mpo1::InfiniteMPO, mpo2::InfiniteMPO)
-    L = check_length(mpo1, mpo2)
-
-    T = promote_type(scalartype(mpo1), scalartype(mpo2))
-    make_fuser(i) = fuser(T, left_virtualspace(mpo2, i), left_virtualspace(mpo1, i))
-
+    check_length(mpo1, mpo2)
     Os = map(fuse_mul_mpo, parent(mpo1), parent(mpo2))
     return InfiniteMPO(Os)
 end

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -308,9 +308,7 @@ function TensorKit.dot(bra::FiniteMPS{T}, mpo::FiniteMPO{<:MPOTensor},
 end
 function TensorKit.dot(bra::InfiniteMPS, mpo::InfiniteMPO, ket::InfiniteMPS;
                        ishermitian=false, krylovdim=30, kwargs...)
-    ρ₀ = similar(bra.AL[1],
-                 left_virtualspace(ket, 1) * left_virtualspace(mpo, 1) ←
-                 left_virtualspace(bra, 1))
+    ρ₀ = allocate_GL(bra, mpo, ket, 1)
     randomize!(ρ₀)
 
     val, = fixedpoint(TransferMatrix(ket.AL, parent(mpo), bra.AL), ρ₀, :LM; ishermitian,

--- a/src/operators/multilinempo.jl
+++ b/src/operators/multilinempo.jl
@@ -13,10 +13,10 @@ See also: [`Multiline`](@ref), [`AbstractMPO`](@ref)
 """
 const MultilineMPO = Multiline{<:AbstractMPO}
 
-function MultilineMPO(Os::AbstractMatrix{T}) where {T}
+function MultilineMPO(Os::AbstractMatrix)
     return MultilineMPO(map(FiniteMPO, eachrow(Os)))
 end
-function MultilineMPO(Os::PeriodicMatrix{T}) where {T}
+function MultilineMPO(Os::PeriodicMatrix)
     return MultilineMPO(map(InfiniteMPO, eachrow(Os)))
 end
 MultilineMPO(mpos::AbstractVector{<:AbstractMPO}) = Multiline(mpos)

--- a/src/operators/multilinempo.jl
+++ b/src/operators/multilinempo.jl
@@ -13,10 +13,10 @@ See also: [`Multiline`](@ref), [`AbstractMPO`](@ref)
 """
 const MultilineMPO = Multiline{<:AbstractMPO}
 
-function MultilineMPO(Os::AbstractMatrix{T}) where {T<:MPOTensor}
+function MultilineMPO(Os::AbstractMatrix{T}) where {T}
     return MultilineMPO(map(FiniteMPO, eachrow(Os)))
 end
-function MultilineMPO(Os::PeriodicMatrix{T}) where {T<:MPOTensor}
+function MultilineMPO(Os::PeriodicMatrix{T}) where {T}
     return MultilineMPO(map(InfiniteMPO, eachrow(Os)))
 end
 MultilineMPO(mpos::AbstractVector{<:AbstractMPO}) = Multiline(mpos)


### PR DESCRIPTION
Attempt at relaxing the type restrictions on MPO elements, in order to be able to use generic effective MPOs. This should work as long as the element type adheres to the (until now implicit) interface for `MPOTensor` which requires:

- `left_virtualspace`
- `right_virtualspace`
- `_conj_mpo`
- `add_physical_charge`
- `_fuse_mpo_mpo`
- `_fuse_mpo_mps`
- `_mpo_to_mps`
- ...?

I also added explicit type annotations for internal methods where an element type `<:MPOTensor` is really assumed.

See also QuantumKitHub/PEPSKit.jl#125 for the intended use case.