### PR TITLE
change default site value for `FiniteMPS` in `entanglement_spectrum`

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -92,7 +92,11 @@ Compute the entanglement spectrum at a given site, i.e. the singular values of t
 matrix to the right of a given site. This is a dictionary mapping the charge to the singular
 values.
 """
-function entanglement_spectrum(st::Union{InfiniteMPS,FiniteMPS,WindowMPS}, site::Int=0)
+function entanglement_spectrum(st::Union{InfiniteMPS,WindowMPS}, site::Int=0)
+    checkbounds(st, site)
+    return LinearAlgebra.svdvals(st.C[site])
+end
+function entanglement_spectrum(st::Union{FiniteMPS}, site::Int=1)
     checkbounds(st, site)
     return LinearAlgebra.svdvals(st.C[site])
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -86,17 +86,21 @@ function transfer_spectrum(above::InfiniteMPS; below=above, tol=Defaults.tol, nu
 end
 
 """
-    entanglement_spectrum(ψ, [site::Int=0]) -> SectorDict{sectortype(ψ),Vector{<:Real}}
+    entanglement_spectrum(ψ, site::Int) -> SectorDict{sectortype(ψ),Vector{<:Real}}
 
 Compute the entanglement spectrum at a given site, i.e. the singular values of the gauge
 matrix to the right of a given site. This is a dictionary mapping the charge to the singular
 values.
+
+For `InfiniteMPS` and `WindowMPS` the default value for `site` is 0.
+
+For `FiniteMPS` no default value for `site` is given, it is up to the user to specify.
 """
 function entanglement_spectrum(st::Union{InfiniteMPS,WindowMPS}, site::Int=0)
     checkbounds(st, site)
     return LinearAlgebra.svdvals(st.C[site])
 end
-function entanglement_spectrum(st::Union{FiniteMPS}, site::Int=1)
+function entanglement_spectrum(st::FiniteMPS, site::Int)
     checkbounds(st, site)
     return LinearAlgebra.svdvals(st.C[site])
 end


### PR DESCRIPTION
As pointed out by @borisdevos, calling `entanglement_spectrum(::FiniteMPS)` does not work as the default value for `site` is 0, which would call the C tensor left of site 0, which does exist, it is just a trivial 1, but throws a `BoundsError` due to the checkbounds in `entanglement_spectrum`.

Currently I just split off the `entanglement_spectrum` method that dispatched on `FiniteMPS` to have a default `site` value of 1. This works but now the docstring is not consistent as it shows a default value of 0 for both methods.

In my opinion having a default value for the finite case really does not make sense and the user should just choose the site according to their needs.

Any opinions?