### PR TITLE
Improve support for mixed `scalartype`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorKitManifolds = "11fa318c-39cb-4a83-b1ed-cdc7ba1e3684"
+TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 
 [compat]
@@ -50,7 +51,6 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -60,6 +60,7 @@ using Compat: @compat
 using TensorKit
 using TensorKit: BraidingTensor
 using BlockTensorKit
+using TensorOperations
 using KrylovKit
 using KrylovKit: KrylovAlgorithm
 using OptimKit

--- a/src/algorithms/timestep/tdvp.jl
+++ b/src/algorithms/timestep/tdvp.jl
@@ -25,9 +25,10 @@ $(TYPEDFIELDS)
     finalize::F = Defaults._finalize
 end
 
-function timestep(ψ::InfiniteMPS, H, t::Number, dt::Number, alg::TDVP,
-                  envs::AbstractMPSEnvironments=environments(ψ, H);
+function timestep(ψ_::InfiniteMPS, H, t::Number, dt::Number, alg::TDVP,
+                  envs::AbstractMPSEnvironments=environments(ψ_, H);
                   leftorthflag=true)
+    ψ = complex(ψ_)
     temp_ACs = similar(ψ.AC)
     temp_Cs = similar(ψ.C)
 
@@ -172,5 +173,5 @@ end
 function timestep(ψ::AbstractFiniteMPS, H, time::Number, timestep::Number,
                   alg::Union{TDVP,TDVP2}, envs::AbstractMPSEnvironments=environments(ψ, H);
                   kwargs...)
-    return timestep!(copy(ψ), H, time, timestep, alg, envs; kwargs...)
+    return timestep!(copy(complex(ψ)), H, time, timestep, alg, envs; kwargs...)
 end

--- a/src/operators/abstractmpo.jl
+++ b/src/operators/abstractmpo.jl
@@ -24,7 +24,9 @@ end
 # Properties
 # ----------
 left_virtualspace(mpo::AbstractMPO, site::Int) = left_virtualspace(mpo[site])
+left_virtualspace(mpo::AbstractMPO) = map(left_virtualspace, parent(mpo))
 right_virtualspace(mpo::AbstractMPO, site::Int) = right_virtualspace(mpo[site])
+right_virtualspace(mpo::AbstractMPO) = map(right_virtualspace, parent(mpo))
 physicalspace(mpo::AbstractMPO, site::Int) = physicalspace(mpo[site])
 physicalspace(mpo::AbstractMPO) = map(physicalspace, mpo)
 

--- a/src/operators/abstractmpo.jl
+++ b/src/operators/abstractmpo.jl
@@ -172,7 +172,11 @@ Base.:*(mpo::AbstractMPO, α::Number) = scale(mpo, α)
 Base.:/(mpo::AbstractMPO, α::Number) = scale(mpo, inv(α))
 Base.:\(α::Number, mpo::AbstractMPO) = scale(mpo, inv(α))
 
-VectorInterface.scale(mpo::AbstractMPO, α::Number) = scale!(copy(mpo), α)
+function VectorInterface.scale(mpo::AbstractMPO, α::Number)
+    T = VectorInterface.promote_scale(scalartype(mpo), scalartype(α))
+    dst = similar(mpo, T)
+    return scale!(dst, mpo, α)
+end
 
 LinearAlgebra.norm(mpo::AbstractMPO) = sqrt(abs(dot(mpo, mpo)))
 

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -24,6 +24,8 @@ Base.length(x::LazySum) = prod(size(x))
 Base.similar(x::LazySum, ::Type{S}, dims::Dims) where {S} = LazySum(similar(x.ops, S, dims))
 Base.setindex!(A::LazySum, X, i::Int) = (setindex!(A.ops, X, i); A)
 
+Base.complex(x::LazySum) = LazySum(complex.(x.ops))
+
 # Holy traits
 TimeDependence(x::LazySum) = istimed(x) ? TimeDependent() : NotTimeDependent()
 istimed(x::LazySum) = any(istimed, x)

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -194,6 +194,13 @@ function VectorInterface.scale!(mpo::MPO, α::Number)
     scale!(first(mpo), α)
     return mpo
 end
+function VectorInterface.scale!(dst::MPO, src::MPO, α::Number)
+    N = check_length(dst, src)
+    for i in 1:N
+        scale!(dst[i], src[i], i == 1 ? α : One())
+    end
+    return dst
+end
 
 function Base.:*(mpo1::FiniteMPO{<:MPOTensor}, mpo2::FiniteMPO{<:MPOTensor})
     check_length(mpo1, mpo2)

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -105,6 +105,8 @@ function Base.convert(::Type{TensorMap}, mpo::FiniteMPO{<:MPOTensor})
     return convert(TensorMap, _instantiate_finitempo(L, M, R))
 end
 
+Base.complex(mpo::MPO) = MPO(map(complex, parent(mpo)))
+
 # Linear Algebra
 # --------------
 # VectorInterface.scalartype(::Type{FiniteMPO{O}}) where {O} = scalartype(O)

--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -533,7 +533,11 @@ function VectorInterface.scale!(dst::MPOHamiltonian, src::MPOHamiltonian,
             isstarting = I[1] == 1 &&
                          ((isfinite(dst) && i == N && I[4] == size(src[i], 4)) ||
                           ((!isfinite(dst) || i != N) && I[4] > 1))
-            dst[i][I] = scale!(dst[i][I], v, isstarting ? λ : One())
+            if v isa BraidingTensor && !isstarting
+                dst[i][I] = v
+            else
+                dst[i][I] = scale!(dst[i][I], v, isstarting ? λ : One())
+            end
         end
     end
     return dst

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -316,6 +316,19 @@ Base.@propagate_inbounds function Base.getindex(ψ::FiniteMPS, i::Int)
     end
 end
 
+_complex_if_not_missing(x) = ismissing(x) ? x : complex(x)
+function Base.complex(mps::FiniteMPS)
+    scalartype(mps) <: Complex && return mps
+    ALs = _complex_if_not_missing.(mps.ALs)
+    ARs = _complex_if_not_missing.(mps.ARs)
+    Cs = _complex_if_not_missing.(mps.Cs)
+    ACs = _complex_if_not_missing.(mps.ACs)
+    return FiniteMPS(collect(Union{Missing,eltype(ALs)}, ALs),
+                     collect(Union{Missing,eltype(ARs)}, ARs),
+                     collect(Union{Missing,eltype(ACs)}, ACs),
+                     collect(Union{Missing,eltype(Cs)}, Cs))
+end
+
 @inline function Base.getindex(ψ::FiniteMPS, I::AbstractUnitRange)
     return Base.getindex.(Ref(ψ), I)
 end

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -224,6 +224,11 @@ function Base.copy!(ψ::InfiniteMPS, ϕ::InfiniteMPS)
     return ψ
 end
 
+function Base.complex(ψ::InfiniteMPS)
+    scalartype(ψ) <: Complex && return ψ
+    return InfiniteMPS(complex.(ψ.AL), complex.(ψ.AR), complex.(ψ.C), complex.(ψ.AC))
+end
+
 function Base.repeat(ψ::InfiniteMPS, i::Int)
     return InfiniteMPS(repeat(ψ.AL, i), repeat(ψ.AR, i), repeat(ψ.C, i), repeat(ψ.AC, i))
 end

--- a/src/states/windowmps.jl
+++ b/src/states/windowmps.jl
@@ -118,6 +118,13 @@ function Base.copy(ψ::WindowMPS)
     return WindowMPS(copy(ψ.left_gs), copy(ψ.window), copy(ψ.right_gs))
 end
 
+function Base.complex(ψ::WindowMPS)
+    scalartype(ψ) <: Complex && return ψ
+    left_gs = complex(ψ.left_gs)
+    right_gs = ψ.left_gs === ψ.right_gs ? left_gs : complex(right_gs)
+    return WindowMPS(left_gs, complex(ψ.window), right_gs)
+end
+
 # not sure about the underlying methods...
 Base.length(ψ::WindowMPS) = length(ψ.window)
 Base.size(ψ::WindowMPS, i...) = size(ψ.window, i...)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -24,28 +24,40 @@ vspaces = (ℙ^10, Rep[U₁]((0 => 20)), Rep[SU₂](1 // 2 => 10, 3 // 2 => 5, 5
     for V in (ℂ^2, U1Space(0 => 1, 1 => 1))
         O₁ = rand(T, V^L, V^L)
         O₂ = rand(T, space(O₁))
+        O₃ = rand(real(T), space(O₁))
 
         # create MPO and convert it back to see if it is the same
         mpo₁ = FiniteMPO(O₁) # type-unstable for now!
         mpo₂ = FiniteMPO(O₂)
+        mpo₃ = FiniteMPO(O₃)
         @test convert(TensorMap, mpo₁) ≈ O₁
         @test convert(TensorMap, -mpo₂) ≈ -O₂
+        @test convert(TensorMap, @constinferred complex(mpo₃)) ≈ complex(O₃)
 
         # test scalar multiplication
         α = rand(T)
         @test convert(TensorMap, α * mpo₁) ≈ α * O₁
         @test convert(TensorMap, mpo₁ * α) ≈ O₁ * α
+        @test α * mpo₃ ≈ α * complex(mpo₃)
 
         # test addition and multiplication
         @test convert(TensorMap, mpo₁ + mpo₂) ≈ O₁ + O₂
+        @test convert(TensorMap, mpo₁ + mpo₃) ≈ O₁ + O₃
         @test convert(TensorMap, mpo₁ * mpo₂) ≈ O₁ * O₂
+        @test convert(TensorMap, mpo₁ * mpo₃) ≈ O₁ * O₃
 
         # test application to a state
         ψ₁ = rand(T, domain(O₁))
+        ψ₂ = rand(real(T), domain(O₂))
         mps₁ = FiniteMPS(ψ₁)
+        mps₂ = FiniteMPS(ψ₂)
 
         @test convert(TensorMap, mpo₁ * mps₁) ≈ O₁ * ψ₁
         @test mpo₁ * ψ₁ ≈ O₁ * ψ₁
+        @test convert(TensorMap, mpo₃ * mps₁) ≈ O₃ * ψ₁
+        @test mpo₃ * ψ₁ ≈ O₃ * ψ₁
+        @test convert(TensorMap, mpo₁ * mps₂) ≈ O₁ * ψ₂
+        @test mpo₁ * ψ₂ ≈ O₁ * ψ₂
 
         @test dot(mps₁, mpo₁, mps₁) ≈ dot(ψ₁, O₁, ψ₁)
         @test dot(mps₁, mpo₁, mps₁) ≈ dot(mps₁, mpo₁ * mps₁)

--- a/test/states.jl
+++ b/test/states.jl
@@ -45,6 +45,15 @@ end
     ψ_small = FiniteMPS(rand, elt, 4, d, D)
     ψ_small2 = FiniteMPS(convert(TensorMap, ψ_small))
     @test dot(ψ_small, ψ_small2) ≈ dot(ψ_small, ψ_small)
+
+    ψ′ = @constinferred complex(ψ)
+    @test scalartype(ψ′) <: Complex
+    if elt <: Complex
+        @test ψ === ψ′
+    else
+        @test norm(ψ) ≈ norm(ψ′)
+        @test complex(convert(TensorMap, ψ)) ≈ convert(TensorMap, ψ′)
+    end
 end
 
 @testset "FiniteMPS center + (slice) indexing" begin

--- a/test/states.jl
+++ b/test/states.jl
@@ -46,13 +46,13 @@ end
     ψ_small2 = FiniteMPS(convert(TensorMap, ψ_small))
     @test dot(ψ_small, ψ_small2) ≈ dot(ψ_small, ψ_small)
 
-    ψ′ = @constinferred complex(ψ)
+    ψ′ = @constinferred complex(ψ_small)
     @test scalartype(ψ′) <: Complex
     if elt <: Complex
-        @test ψ === ψ′
+        @test ψ_small === ψ′
     else
-        @test norm(ψ) ≈ norm(ψ′)
-        @test complex(convert(TensorMap, ψ)) ≈ convert(TensorMap, ψ′)
+        @test norm(ψ_small) ≈ norm(ψ′)
+        @test complex(convert(TensorMap, ψ_small)) ≈ convert(TensorMap, ψ′)
     end
 end
 


### PR DESCRIPTION
This adds and refactors some functionality to improve the coverage of dealing with mixed scalartypes.
In particular, I've added implementations for `Base.complex` for cases when one wishes to go from `<:Real` to `<:Complex` entries.
This is particularly useful for example in the case of a `Real` groundstate, where time evolution methods would result in complex states, which currently errors.

Fixes #258 