### PR TITLE
Expand `exact_diagonalization` and `FiniteMPS` docstrings

### DIFF
--- a/src/algorithms/ED.jl
+++ b/src/algorithms/ED.jl
@@ -8,6 +8,27 @@
 Use [`KrylovKit.eigsolve`](@extref) to perform exact diagonalization on a
 `FiniteMPOHamiltonian` to find its eigenvectors as `FiniteMPS` of maximal rank, essentially
 equivalent to dense eigenvectors.
+
+### Arguments
+- `opp::FiniteMPOHamiltonian`: the Hamiltonian to diagonalize.
+
+### Keyword arguments
+- `sector=first(sectors(oneunit(physicalspace(opp, 1))))`: the total charge of the
+  eigenvectors, which is chosen trivial by default.
+- `len::Int=length(opp)`: the length of the system.
+- `num::Int=1`: the number of eigenvectors to find.
+- `which::Symbol=:SR`: the kind eigenvalues to find, see [`KrylovKit.eigsolve`](@extref). 
+- `alg=Defaults.alg_eigsolve(; dynamic_tols=false)`: the diagonalization algorithm to use,
+  see [`KrylovKit.eigsolve`](@extref).
+
+!!! note "Valid `sector` values"
+    The total charge of the eigenvectors is imposed by adding a charged auxiliary space as
+    the leftmost virtualspace of each eigenvector. Specifically, this is achieved by passing
+    `left=Vect[typeof(sector)](sector => 1)` to the [`FiniteMPS`](@ref) constructor. As
+    such, the only valid `sector` values (i.e. a `sector` value for which the corresponding
+    eigenstate has valid fusion channels) are those that occur in the dual of the fusion of
+    all the physical spaces in the system.
+
 """
 function exact_diagonalization(opp::FiniteMPOHamiltonian;
                                sector=first(sectors(oneunit(physicalspace(opp, 1)))),

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -34,7 +34,9 @@ By convention, we have that:
     FiniteMPS(As::Vector{<:GenericMPSTensor}; normalize=false, overwrite=false)
 
 Construct an MPS via a specification of physical and virtual spaces, or from a list of
-tensors `As`. All cases reduce to the latter.
+tensors `As`. All cases reduce to the latter. In particular, a state with a non-trivial
+total charge can be constructed by passing a non-trivially charged vector space as the
+`left` or `right` virtual spaces.
 
 ### Arguments
 - `As::Vector{<:GenericMPSTensor}`: vector of site tensors
@@ -50,7 +52,7 @@ tensors `As`. All cases reduce to the latter.
 - `maxvirtualspace::S`: maximum virtual space
 
 ### Keywords
-- `normalize`: normalize the constructed state
+- `normalize=true`: normalize the constructed state
 - `overwrite=false`: overwrite the given input tensors
 - `left=oneunit(S)`: left-most virtual space
 - `right=oneunit(S)`: right-most virtual space


### PR DESCRIPTION
Some docstring additions on how to obtain charged eigenstates using `exact_diagonalization`. I also added a line on charged states in the `FiniteMPS` docstring, since this is very related and there have been complaints about this not being clear in the past.