### PR TITLE
Update mpo.jl

### DIFF
--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -290,14 +290,14 @@ function TensorKit.dot(bra::FiniteMPS{T}, mpo::FiniteMPO{<:MPOTensor},
     # right half
     ρ_right = isomorphism(storagetype(T),
                           right_virtualspace(ket, N) ⊗ right_virtualspace(mpo, N),
-                          right_virtualspace(ket, length(ket)))
+                          right_virtualspace(bra, N))
     T_right = TransferMatrix(ket.AR[(Nhalf + 1):end], mpo[(Nhalf + 1):end],
                              bra.AR[(Nhalf + 1):end])
     ρ_right = T_right * ρ_right
 
     # center
     return @plansor ρ_left[3 4; 1] * ket.C[Nhalf][1; 5] * ρ_right[5 4; 2] *
-                    conj(ket.C[Nhalf][3; 2])
+                    conj(bra.C[Nhalf][3; 2])
 end
 function TensorKit.dot(bra::InfiniteMPS, mpo::InfiniteMPO, ket::InfiniteMPS;
                        ishermitian=false, krylovdim=30, kwargs...)


### PR DESCRIPTION
Correction of TensorKit.dot function.
It was incorrect for bra \neq ket case. This was problematic for non-Hermitian calculations.