### PR TITLE
Change `environments` calling syntax for inifinite MPS

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -36,8 +36,8 @@ function infinite_temperature_density_matrix(H::MPOHamiltonian)
 end
 
 """
-    calc_galerkin(above, operator, below, envs)
-    calc_galerkin(pos, above, operator, below, envs)
+    calc_galerkin(below, operator, above, envs)
+    calc_galerkin(pos, below, operator, above, envs)
 
 Calculate the Galerkin error, which is the error between the solution of the original problem, and the solution of the problem projected on the tangent space.
 Concretely, this is the overlap of the current state with the single-site derivative, projected onto the nullspace of the current state:
@@ -46,25 +46,25 @@ Concretely, this is the overlap of the current state with the single-site deriva
 \\epsilon = |VL * (VL' * \\frac{above}{\\partial AC_{pos}})|
 ```
 """
-function calc_galerkin(pos::Int, above::Union{InfiniteMPS,FiniteMPS,WindowMPS}, operator,
-                       below, envs)
-    AC´ = ∂∂AC(pos, above, operator, envs) * above.AC[pos]
+function calc_galerkin(pos::Int, below::Union{InfiniteMPS,FiniteMPS,WindowMPS}, operator,
+                       above, envs)
+    AC´ = ∂∂AC(pos, below, operator, envs) * above.AC[pos]
     normalize!(AC´)
     out = add!(AC´, below.AL[pos] * below.AL[pos]' * AC´, -1)
     return norm(out)
 end
-function calc_galerkin(pos::CartesianIndex{2}, above::MultilineMPS, operator::MultilineMPO,
-                       below::MultilineMPS, envs::MultilineEnvironments)
+function calc_galerkin(pos::CartesianIndex{2}, below::MultilineMPS, operator::MultilineMPO,
+                       above::MultilineMPS, envs::MultilineEnvironments)
     row, col = pos.I
-    return calc_galerkin(col, above[row], operator[row], below[row + 1], envs[row])
+    return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
-function calc_galerkin(above::Union{InfiniteMPS,FiniteMPS,WindowMPS}, operator,
-                       below, envs)
-    return maximum(pos -> calc_galerkin(pos, above, operator, below, envs), 1:length(above))
+function calc_galerkin(below::Union{InfiniteMPS,FiniteMPS,WindowMPS}, operator,
+                       above, envs)
+    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
 end
-function calc_galerkin(above::MultilineMPS, operator::MultilineMPO, below::MultilineMPS,
+function calc_galerkin(below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,
                        envs::MultilineEnvironments)
-    return maximum(pos -> calc_galerkin(pos, above, operator, below, envs),
+    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs),
                    CartesianIndices(size(above)))
 end
 

--- a/src/environments/abstract_envs.jl
+++ b/src/environments/abstract_envs.jl
@@ -64,7 +64,7 @@ end
 # Environment algorithms
 # ----------------------
 """
-    environment_alg(above, operator, below; kwargs...)
+    environment_alg(below, operator, above; kwargs...)
 
 Determine an appropriate algorithm for computing the environments, based on the given `kwargs...`.
 """
@@ -76,7 +76,7 @@ function environment_alg(::Union{InfiniteMPS,MultilineMPS},
                          eager=true)
     return Arnoldi(; tol, maxiter, krylovdim, verbosity, eager)
 end
-function environment_alg(above, ::InfiniteMPOHamiltonian, below;
+function environment_alg(below, ::InfiniteMPOHamiltonian, above;
                          tol=Defaults.tol, maxiter=Defaults.maxiter,
                          krylovdim=Defaults.krylovdim, verbosity=Defaults.VERBOSE_NONE)
     return GMRES(; tol, maxiter, krylovdim, verbosity)

--- a/src/environments/multiline_envs.jl
+++ b/src/environments/multiline_envs.jl
@@ -1,38 +1,38 @@
 const MultilineEnvironments{E<:AbstractMPSEnvironments} = Multiline{E}
 
-function environments(above::MultilineMPS, operator::MultilineMPO,
-                      below::MultilineMPS=above; kwargs...)
+function environments(below::MultilineMPS, operator::MultilineMPO,
+                      above::MultilineMPS=below; kwargs...)
     (rows = size(above, 1)) == size(operator, 1) == size(below, 1) ||
         throw(ArgumentError("Incompatible sizes"))
     envs = map(1:rows) do row
-        return environments(above[row], operator[row], below[row + 1]; kwargs...)
+        return environments(below[row + 1], operator[row], above[row]; kwargs...)
     end
     return Multiline(PeriodicVector(envs))
 end
 
-function recalculate!(envs::MultilineEnvironments, above::MultilineMPS,
-                      operator::MultilineMPO, below::MultilineMPS=above; kwargs...)
+function recalculate!(envs::MultilineEnvironments, below::MultilineMPS,
+                      operator::MultilineMPO, above::MultilineMPS=below; kwargs...)
     (rows = size(above, 1)) == size(operator, 1) == size(below, 1) ||
         throw(ArgumentError("Incompatible sizes"))
     @threads for row in 1:rows
-        recalculate!(envs[row], above[row], operator[row], below[row + 1]; kwargs...)
+        recalculate!(envs[row], below[row + 1], operator[row], above[row]; kwargs...)
     end
     return envs
 end
 function recalculate!(envs::MultilineEnvironments, below, (operator, above)::Tuple;
                       kwargs...)
-    return recalculate!(envs, above, operator, below; kwargs...)
+    return recalculate!(envs, below, operator, above; kwargs...)
 end
 
-function TensorKit.normalize!(envs::MultilineEnvironments, above, operator, below)
-    for row in 1:size(above, 1)
-        normalize!(envs[row], above[row], operator[row], below[row + 1])
+function TensorKit.normalize!(envs::MultilineEnvironments, below, operator, above)
+    for row in 1:size(below, 1)
+        normalize!(envs[row], below[row + 1], operator[row], above[row])
     end
     return envs
 end
 function TensorKit.normalize!(envs::MultilineEnvironments, below, (operator, above))
     for row in 1:size(above, 1)
-        normalize!(envs[row], above[row], operator[row], below[row + 1])
+        normalize!(envs[row], below[row + 1], operator[row], above[row])
     end
     return envs
 end
@@ -44,22 +44,22 @@ function rightenv(envs::MultilineEnvironments, col::Int, state)
     return rightenv.(parent(envs), col, parent(state))
 end
 
-function transfer_leftenv!(envs::MultilineEnvironments, above, operator, below, site::Int)
+function transfer_leftenv!(envs::MultilineEnvironments, below, operator, above, site::Int)
     for row in 1:size(above, 1)
-        transfer_leftenv!(envs[row], above[row], operator[row], below[row + 1], site)
+        transfer_leftenv!(envs[row], below[row + 1], operator[row], above[row], site)
     end
     return envs
 end
 function transfer_leftenv!(envs::MultilineEnvironments, below, (O, above)::Tuple, site::Int)
-    return transfer_leftenv!(envs, above, O, below, site)
+    return transfer_leftenv!(envs, below, O, above, site)
 end
-function transfer_rightenv!(envs::MultilineEnvironments, above, operator, below, site::Int)
+function transfer_rightenv!(envs::MultilineEnvironments, below, operator, above, site::Int)
     for row in 1:size(above, 1)
-        transfer_rightenv!(envs[row], above[row], operator[row], below[row + 1], site)
+        transfer_rightenv!(envs[row], below[row + 1], operator[row], above[row], site)
     end
     return envs
 end
 function transfer_rightenv!(envs::MultilineEnvironments, below, (O, above)::Tuple,
                             site::Int)
-    return transfer_rightenv!(envs, above, O, below, site)
+    return transfer_rightenv!(envs, below, O, above, site)
 end

--- a/src/environments/multiple_envs.jl
+++ b/src/environments/multiple_envs.jl
@@ -28,10 +28,10 @@ end
 """
     Recalculate in-place each sub-env in MultipleEnvironments
 """
-function recalculate!(envs::MultipleEnvironments, above, operator::LazySum, below=above;
+function recalculate!(envs::MultipleEnvironments, below, operator::LazySum, above=below;
                       kwargs...)
     for (subenvs, subO) in zip(envs.envs, operator)
-        recalculate!(subenvs, above, subO, below; kwargs...)
+        recalculate!(subenvs, below, subO, above; kwargs...)
     end
     return envs
 end
@@ -46,17 +46,17 @@ function Base.getproperty(envs::MultipleEnvironments, prop::Symbol)
 end
 
 function transfer_rightenv!(envs::MultipleEnvironments{<:InfiniteEnvironments},
-                            above, operator, below, pos::Int)
+                            below, operator, above, pos::Int)
     for (subH, subenv) in zip(operator, envs.envs)
-        transfer_rightenv!(subenv, above, subH, below, pos)
+        transfer_rightenv!(subenv, below, subH, above, pos)
     end
     return envs
 end
 
 function transfer_leftenv!(envs::MultipleEnvironments{<:InfiniteEnvironments},
-                           above, operator, below, pos::Int)
+                           below, operator, above, pos::Int)
     for (subH, subenv) in zip(operator, envs.envs)
-        transfer_leftenv!(subenv, above, subH, below, pos)
+        transfer_leftenv!(subenv, below, subH, above, pos)
     end
     return envs
 end

--- a/src/operators/multipliedoperator.jl
+++ b/src/operators/multipliedoperator.jl
@@ -52,6 +52,6 @@ Base.:*(op::UntimedOperator, g::Function) = MultipliedOperator(op.op, t -> g(t) 
 function environments(st, x::MultipliedOperator, args...; kwargs...)
     return environments(st, x.op, args...; kwargs...)
 end
-function recalculate!(envs, above, x::MultipliedOperator, below=above; kwargs...)
-    return recalculate!(envs, above, x.op, below; kwargs...)
+function recalculate!(envs, below, x::MultipliedOperator, above=below; kwargs...)
+    return recalculate!(envs, below, x.op, above; kwargs...)
 end


### PR DESCRIPTION
Changes the syntax convention for infinite MPS environment-related methods to `(below, operator, above=below)`, in line with the finite MPS convention. Since `above` is always the optional one from the point of view of boundary MPS algorithms, this made more sense. I didn't change any of the `TransferMatrix` related code, which still assumes `(above, operator, below=above)` for its arguments. I suspect changing this would cause a lot more downstream issues.

In the process I noticed that `calc_galerkin` would have been wrong when used in `approximate` for finite MPS, and after that noticed that we don't actually use the proper Galerkin error in the finite approximate. I think we could, and probably should? But this can be addressed in a follow-up I think.

Fixes #267.