### PR TITLE
Fix `add_physical_charge` for `JordanMPOTensor`

### DIFF
--- a/src/operators/jordanmpotensor.jl
+++ b/src/operators/jordanmpotensor.jl
@@ -307,6 +307,19 @@ function _conj_mpo(W::JordanMPOTensor)
     return JordanMPOTensor(V, A, B, C, D)
 end
 
+function add_physical_charge(O::JordanMPOTensor, charge::Sector)
+    sectortype(O) == typeof(charge) || throw(SectorMismatch())
+    auxspace = Vect[typeof(charge)](charge => 1)'
+    Vdst = left_virtualspace(O) ⊗
+           fuse(physicalspace(O), auxspace) ←
+           fuse(physicalspace(O), auxspace) ⊗ right_virtualspace(O)
+    Odst = JordanMPOTensor{scalartype(O)}(undef, Vdst)
+    for (I, v) in nonzero_pairs(O)
+        Odst[I] = add_physical_charge(v, charge)
+    end
+    return Odst
+end
+
 # Utility
 # -------
 function Base.copy(W::JordanMPOTensor)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -920,7 +920,7 @@ end
 
 @testset "Sector conventions" begin
     L = 4
-    H = TestSetup.XY_model(U1Irrep; L)
+    H = XY_model(U1Irrep; L)
 
     H_dense = convert(TensorMap, H)
     vals_dense = eigvals(H_dense)


### PR DESCRIPTION
Implement a corrected version of the `add_physical_charge` function for `JordanMPOTensor` and remove an unnecessary name qualifier in the test setup.