### PR TITLE
Add tests for fermionic periodic boundary conditions

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -274,9 +274,11 @@ function periodic_boundary_conditions(mpo::InfiniteMPO{O},
         F_left = i == 1 ? cup : F_right
         F_right = i == L ? cup :
                   isomorphism(ST, V_right ← V_wrap' * right_virtualspace(mpo, i))
+        # account for fermionic boundary conditions
+        o = i == L ? twist(mpo[i], 4) : mpo[i]
         @plansor output[i][-1 -2; -3 -4] = F_left[-1; 1 2] *
                                            τ[-3 1; 4 3] *
-                                           mpo[i][2 -2; 3 5] *
+                                           o[2 -2; 3 5] *
                                            conj(F_right[-4; 4 5])
     end
 
@@ -421,7 +423,9 @@ function periodic_boundary_conditions(H::InfiniteMPOHamiltonian, L=length(H))
             F_left = fusers[end][j, k, chi]
             k′ = indmap[j, k, chi]
             k′ == size(output[end], 1) && continue
-            @plansor o[-1 -2; -3 -4] := F_left[-1; 1 2 6] * h[1 3; -3 4] * τ[3 2; 4 5] *
+            # apply twist for fermionic boundary conditions
+            h′ = twist(h, 4)
+            @plansor o[-1 -2; -3 -4] := F_left[-1; 1 2 6] * h′[1 3; -3 4] * τ[3 2; 4 5] *
                                         τ[5 6; -4 -2]
             output[end][k′, 1, 1, 1] = o
         end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -275,7 +275,7 @@ function periodic_boundary_conditions(mpo::InfiniteMPO{O},
         F_right = i == L ? cup :
                   isomorphism(ST, V_right ← V_wrap' * right_virtualspace(mpo, i))
         # account for fermionic boundary conditions
-        o = i == L ? twist(mpo[i], 4) : mpo[i]
+        o = i == L ? _twist(mpo[i], 4) : mpo[i]
         @plansor output[i][-1 -2; -3 -4] = F_left[-1; 1 2] *
                                            τ[-3 1; 4 3] *
                                            o[2 -2; 3 5] *
@@ -424,8 +424,8 @@ function periodic_boundary_conditions(H::InfiniteMPOHamiltonian, L=length(H))
             k′ = indmap[j, k, chi]
             k′ == size(output[end], 1) && continue
             # apply twist for fermionic boundary conditions
-            h′ = twist(h, 4)
-            @plansor o[-1 -2; -3 -4] := F_left[-1; 1 2 6] * h′[1 3; -3 4] * τ[3 2; 4 5] *
+            h = _twist(h, 4)
+            @plansor o[-1 -2; -3 -4] := F_left[-1; 1 2 6] * h[1 3; -3 4] * τ[3 2; 4 5] *
                                         τ[5 6; -4 -2]
             output[end][k′, 1, 1, 1] = o
         end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -274,11 +274,9 @@ function periodic_boundary_conditions(mpo::InfiniteMPO{O},
         F_left = i == 1 ? cup : F_right
         F_right = i == L ? cup :
                   isomorphism(ST, V_right ← V_wrap' * right_virtualspace(mpo, i))
-        # account for fermionic boundary conditions
-        o = i == L ? _twist(mpo[i], 4) : mpo[i]
         @plansor output[i][-1 -2; -3 -4] = F_left[-1; 1 2] *
                                            τ[-3 1; 4 3] *
-                                           o[2 -2; 3 5] *
+                                           mpo[i][2 -2; 3 5] *
                                            conj(F_right[-4; 4 5])
     end
 
@@ -423,8 +421,6 @@ function periodic_boundary_conditions(H::InfiniteMPOHamiltonian, L=length(H))
             F_left = fusers[end][j, k, chi]
             k′ = indmap[j, k, chi]
             k′ == size(output[end], 1) && continue
-            # apply twist for fermionic boundary conditions
-            h = _twist(h, 4)
             @plansor o[-1 -2; -3 -4] := F_left[-1; 1 2 6] * h[1 3; -3 4] * τ[3 2; 4 5] *
                                         τ[5 6; -4 -2]
             output[end][k′, 1, 1, 1] = o

--- a/src/transfermatrix/transfer.jl
+++ b/src/transfermatrix/transfer.jl
@@ -68,25 +68,21 @@ end
 # the transfer operation of a density matrix with a utility leg in its codomain is ill defined - how should one braid the utility leg?
 # hence the checks - to make sure that this operation is uniquely defined
 function transfer_left(v::MPSTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    _can_unambiguously_braid(space(v, 2)) ||
-        throw(ArgumentError("transfer is not uniquely defined with utility space $(space(v,2))"))
+    check_ambiguous_braiding(space(v, 2))
     @plansor v[-1 -2; -3] := v[1 2; 4] * A[4 5; -3] * τ[2 3; 5 -2] * conj(Ab[1 3; -1])
 end
 function transfer_right(v::MPSTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    _can_unambiguously_braid(space(v, 2)) ||
-        throw(ArgumentError("transfer is not uniquely defined with utility space $(space(v,2))"))
+    check_ambiguous_braiding(space(v, 2))
     @plansor v[-1 -2; -3] := A[-1 2; 1] * τ[-2 4; 2 3] * conj(Ab[-3 4; 5]) * v[1 3; 5]
 end
 
 # the transfer operation with a utility leg in both the domain and codomain is also ill defined - only due to the codomain utility space
 function transfer_left(v::MPOTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    _can_unambiguously_braid(space(v, 2)) ||
-        throw(ArgumentError("transfer is not uniquely defined with utility space $(space(v,2))"))
+    check_ambiguous_braiding(space(v, 2))
     @plansor t[-1 -2; -3 -4] := v[1 2; -3 4] * A[4 5; -4] * τ[2 3; 5 -2] * conj(Ab[1 3; -1])
 end
 function transfer_right(v::MPOTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    _can_unambiguously_braid(space(v, 2)) ||
-        throw(ArgumentError("transfer is not uniquely defined with utility space $(space(v,2))"))
+    check_ambiguous_braiding(space(v, 2))
     @plansor t[-1 -2; -3 -4] := A[-1 2; 1] * τ[-2 4; 2 3] * conj(Ab[-4 4; 5]) * v[1 3; -3 5]
 end
 

--- a/src/transfermatrix/transfer.jl
+++ b/src/transfermatrix/transfer.jl
@@ -68,21 +68,21 @@ end
 # the transfer operation of a density matrix with a utility leg in its codomain is ill defined - how should one braid the utility leg?
 # hence the checks - to make sure that this operation is uniquely defined
 function transfer_left(v::MPSTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    check_ambiguous_braiding(space(v, 2))
+    check_unambiguous_braiding(space(v, 2))
     @plansor v[-1 -2; -3] := v[1 2; 4] * A[4 5; -3] * τ[2 3; 5 -2] * conj(Ab[1 3; -1])
 end
 function transfer_right(v::MPSTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    check_ambiguous_braiding(space(v, 2))
+    check_unambiguous_braiding(space(v, 2))
     @plansor v[-1 -2; -3] := A[-1 2; 1] * τ[-2 4; 2 3] * conj(Ab[-3 4; 5]) * v[1 3; 5]
 end
 
 # the transfer operation with a utility leg in both the domain and codomain is also ill defined - only due to the codomain utility space
 function transfer_left(v::MPOTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    check_ambiguous_braiding(space(v, 2))
+    check_unambiguous_braiding(space(v, 2))
     @plansor t[-1 -2; -3 -4] := v[1 2; -3 4] * A[4 5; -4] * τ[2 3; 5 -2] * conj(Ab[1 3; -1])
 end
 function transfer_right(v::MPOTensor{S}, A::MPSTensor{S}, Ab::MPSTensor{S}) where {S}
-    check_ambiguous_braiding(space(v, 2))
+    check_unambiguous_braiding(space(v, 2))
     @plansor t[-1 -2; -3 -4] := A[-1 2; 1] * τ[-2 4; 2 3] * conj(Ab[-4 4; 5]) * v[1 3; -3 5]
 end
 

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -89,7 +89,6 @@ function _embedders(spaces)
     return maps
 end
 
-
 #=
 map every element in the tensormap to dfun(E)
 allows us to create random tensormaps for any storagetype
@@ -151,5 +150,5 @@ function check_ambiguous_braiding(::Type{Bool}, V::VectorSpace)
 end
 function check_ambiguous_braiding(V::VectorSpace)
     return check_ambiguous_braiding(Bool, V) ||
-        throw(ArgumentError("cannot unambiguously braid $V"))
+           throw(ArgumentError("cannot unambiguously braid $V"))
 end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -133,6 +133,15 @@ function fuser(::Type{T}, V1::S, V2::S) where {T,S<:IndexSpace}
     return isomorphism(T, fuse(V1 ⊗ V2), V1 ⊗ V2)
 end
 
+# TODO: remove once TensorKit supports this
+_twist(t::AbstractTensorMap, i::Int) = _twist(BraidingStyle(sectortype(t)), t, i)
+_twist(::SymmetricBraiding, t::AbstractTensorMap, i::Int) = t
+function _twist(::NoBraiding, t::AbstractTensorMap, i::Int)
+    check_ambiguous_braiding(space(t, i))
+    return t
+end
+_twist(::BraidingStyle, t::AbstractTensorMap, i::Int) = twist(t, i)
+
 # Verify that the braiding is unambiguous: either through symmetric braiding or because the
 # sectors are all trivial
 function check_ambiguous_braiding(::Type{Bool}, V::VectorSpace)

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -89,17 +89,6 @@ function _embedders(spaces)
     return maps
 end
 
-function _can_unambiguously_braid(sp::VectorSpace)
-    s = sectortype(sp)
-
-    BraidingStyle(s) isa SymmetricBraiding && return true
-
-    # if it's not symmetric, then we are only really garantueed that this is possible when only one irrep occurs - the trivial one
-    for sect in sectors(sp)
-        sect == one(sect) || return false
-    end
-    return true
-end
 
 #=
 map every element in the tensormap to dfun(E)
@@ -142,4 +131,16 @@ end
 
 function fuser(::Type{T}, V1::S, V2::S) where {T,S<:IndexSpace}
     return isomorphism(T, fuse(V1 ⊗ V2), V1 ⊗ V2)
+end
+
+# Verify that the braiding is unambiguous: either through symmetric braiding or because the
+# sectors are all trivial
+function check_ambiguous_braiding(::Type{Bool}, V::VectorSpace)
+    I = sectortype(V)
+    BraidingStyle(I) isa SymmetricBraiding && return true
+    return all(isone, sectors(V))
+end
+function check_ambiguous_braiding(V::VectorSpace)
+    return check_ambiguous_braiding(Bool, V) ||
+        throw(ArgumentError("cannot unambiguously braid $V"))
 end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -134,21 +134,21 @@ end
 
 # TODO: remove once TensorKit supports this
 _twist(t::AbstractTensorMap, i::Int) = _twist(BraidingStyle(sectortype(t)), t, i)
-_twist(::SymmetricBraiding, t::AbstractTensorMap, i::Int) = t
+_twist(::Bosonic, t::AbstractTensorMap, i::Int) = t
 function _twist(::NoBraiding, t::AbstractTensorMap, i::Int)
-    check_ambiguous_braiding(space(t, i))
+    check_unambiguous_braiding(space(t, i))
     return t
 end
 _twist(::BraidingStyle, t::AbstractTensorMap, i::Int) = twist(t, i)
 
 # Verify that the braiding is unambiguous: either through symmetric braiding or because the
 # sectors are all trivial
-function check_ambiguous_braiding(::Type{Bool}, V::VectorSpace)
+function check_unambiguous_braiding(::Type{Bool}, V::VectorSpace)
     I = sectortype(V)
     BraidingStyle(I) isa SymmetricBraiding && return true
     return all(isone, sectors(V))
 end
-function check_ambiguous_braiding(V::VectorSpace)
-    return check_ambiguous_braiding(Bool, V) ||
+function check_unambiguous_braiding(V::VectorSpace)
+    return check_unambiguous_braiding(Bool, V) ||
            throw(ArgumentError("cannot unambiguously braid $V"))
 end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -132,17 +132,14 @@ function fuser(::Type{T}, V1::S, V2::S) where {T,S<:IndexSpace}
     return isomorphism(T, fuse(V1 ⊗ V2), V1 ⊗ V2)
 end
 
-# TODO: remove once TensorKit supports this
-_twist(t::AbstractTensorMap, i::Int) = _twist(BraidingStyle(sectortype(t)), t, i)
-_twist(::Bosonic, t::AbstractTensorMap, i::Int) = t
-function _twist(::NoBraiding, t::AbstractTensorMap, i::Int)
-    check_unambiguous_braiding(space(t, i))
-    return t
-end
-_twist(::BraidingStyle, t::AbstractTensorMap, i::Int) = twist(t, i)
+"""
+    check_unambiguous_braiding(::Type{Bool}, V::VectorSpace)::Bool
+    check_unambiguous_braiding(V::VectorSpace)
 
-# Verify that the braiding is unambiguous: either through symmetric braiding or because the
-# sectors are all trivial
+Verify that the braiding of a vector space is unambiguous. This is the case if the braiding
+is symmetric or if all sectors are trivial. The signature with `Type{Bool}` is used to check
+while the signature without is used to throw an error if the braiding is ambiguous.
+"""
 function check_unambiguous_braiding(::Type{Bool}, V::VectorSpace)
     I = sectortype(V)
     BraidingStyle(I) isa SymmetricBraiding && return true

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -759,7 +759,7 @@ end
 
 @testset "periodic boundary conditions" begin
     Hs = [transverse_field_ising(), heisenberg_XXX(), classical_ising(), sixvertex()]
-    for N in 2:5
+    for N in 2:6
         for H in Hs
             TH = convert(TensorMap, periodic_boundary_conditions(H, N))
             @test TH ≈
@@ -773,7 +773,7 @@ end
         H = InfiniteMPOHamiltonian([space(h, 1)], (1, 2) => h)
         H_periodic = periodic_boundary_conditions(H, N)
         terms = [(i, i + 1) => h for i in 1:(N - 1)]
-        push!(terms, (1, N) => -h)
+        push!(terms, (1, N) => h)
         H_periodic2 = FiniteMPOHamiltonian(physicalspace(H_periodic), terms)
         @test H_periodic ≈ H_periodic2
     end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -759,12 +759,23 @@ end
 
 @testset "periodic boundary conditions" begin
     Hs = [transverse_field_ising(), heisenberg_XXX(), classical_ising(), sixvertex()]
-    for N in 2:6
+    for N in 2:5
         for H in Hs
             TH = convert(TensorMap, periodic_boundary_conditions(H, N))
             @test TH ≈
                   permute(TH, ((vcat(N, 1:(N - 1))...,), (vcat(2N, (N + 1):(2N - 1))...,)))
         end
+    end
+
+    # fermionic tests
+    for N in 3:5
+        h = real(c_plusmin() + c_minplus())
+        H = InfiniteMPOHamiltonian([space(h, 1)], (1, 2) => h)
+        H_periodic = periodic_boundary_conditions(H, N)
+        terms = [(i, i + 1) => h for i in 1:(N - 1)]
+        push!(terms, (1, N) => -h)
+        H_periodic2 = FiniteMPOHamiltonian(physicalspace(H_periodic), terms)
+        @test H_periodic ≈ H_periodic2
     end
 end
 


### PR DESCRIPTION
Implement fixes for handling fermionic periodic boundary conditions and adds some tests.

I have to say that this still absolutely confuses me, and I can't really wrap my head around this very well.
The bottom line is that if I understand everything correctly, even though our formalism works, it cannot correctly account for the anticommutation relations on different sites:

```julia
using MPSKitModels
h_ij = c_plusmin() + c_minplus()
h_ji = permute(h_ij, ((2, 1), (4, 3)))
h_ij ≈ -h_ji # false!!
h_ij ≈ h_ji # true
```

I don't think there is any way around this, but I might be mistaken here.

In any case, with this in mind, the previous implementation of PBC did not account for this, so here I added a twist on every link that needs to wrap around.

I think the tests should capture this correctly, but I'm still confused by this entire endeavor, since if I am understanding this correctly, for fermionic systems the following does not hold, while it is what I understand from translation invariance for bosonic systems:

```julia
H = # some tensor representing a translation invariant hamiltonian
isapprox(H, permute(H, (TupleTools.circshift(codomainind(H), 1), TupleTools.circshift(domainind(H), 1)))
```

@Jutho if you could confirm that this is indeed expected, that would be greatly appreciated.