### PR TITLE
fix typo in `localupdate_step` for `VOMPS` algorithm

### DIFF
--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -65,9 +65,9 @@ function localupdate_step!(::IterativeSolver{<:VOMPS}, state::VOMPSState{<:Any,<
     dst_ACs = state.mps isa Multiline ? eachcol(ACs) : ACs
 
     foreach(eachsite) do site
-        AC = circshift([ac_proj(row, site, state.mps, state.toapprox, state.envs)
+        AC = circshift([ac_proj(row, site, state.mps, state.operator, state.envs)
                         for row in 1:size(state.mps, 1)], 1)
-        C = circshift([c_proj(row, site, state.mps, state.toapprox, state.envs)
+        C = circshift([c_proj(row, site, state.mps, state.operator, state.envs)
                        for row in 1:size(state.mps, 1)], 1)
         dst_ACs[site] = regauge!(AC, C; alg=alg_orth)
         return nothing

--- a/src/algorithms/approximate/vomps.jl
+++ b/src/algorithms/approximate/vomps.jl
@@ -65,9 +65,9 @@ function localupdate_step!(::IterativeSolver{<:VOMPS}, state::VOMPSState{<:Any,<
     dst_ACs = state.mps isa Multiline ? eachcol(ACs) : ACs
 
     foreach(eachsite) do site
-        AC = circshift([ac_proj(row, loc, state.mps, state.toapprox, state.envs)
+        AC = circshift([ac_proj(row, site, state.mps, state.toapprox, state.envs)
                         for row in 1:size(state.mps, 1)], 1)
-        C = circshift([c_proj(row, loc, state.mps, state.toapprox, state.envs)
+        C = circshift([c_proj(row, site, state.mps, state.toapprox, state.envs)
                        for row in 1:size(state.mps, 1)], 1)
         dst_ACs[site] = regauge!(AC, C; alg=alg_orth)
         return nothing

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -701,7 +701,10 @@ end
         W2 = MPSKit.DenseMPO(sW2)
 
         ψ1, _ = approximate(ψ0, (sW1, ψ), VOMPS(; verbosity))
+        MPSKit.Defaults.set_scheduler!(:serial)
         ψ2, _ = approximate(ψ0, (W2, ψ), VOMPS(; verbosity))
+        MPSKit.Defaults.set_scheduler!()
+
         ψ3, _ = approximate(ψ0, (W1, ψ), IDMRG(; verbosity))
         ψ4, _ = approximate(ψ0, (sW2, ψ), IDMRG2(; trscheme=truncdim(12), verbosity))
         ψ5, _ = timestep(ψ, H, 0.0, dt, TDVP())


### PR DESCRIPTION
`VOMPS` was giving @borisdevos issues. It seems that the recent Refactor PR #265 made a small mistake in the `localupdate_step!` function for `VOMPS` and the lines were not covered by the tests.