### PR TITLE
Make `changebonds` truncation use relative truncation schemes.

### DIFF
--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -30,7 +30,7 @@ function changebonds(ψ::InfiniteMPS, H::InfiniteMPOHamiltonian, alg::OptimalExp
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = leftnull(ψ.AL[i])
         VR = rightnull!(_transpose_tail(ψ.AR[i + 1]))
-        intermediate = adjoint(VL) * AC2 * adjoint(VR)
+        intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, V, = tsvd!(intermediate; trunc=alg.trscheme, alg=alg.alg_svd)
 
         AL′[i] = VL * U
@@ -56,7 +56,7 @@ function changebonds(ψ::MultilineMPS, H, alg::OptimalExpand, envs=environments(
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = leftnull(ψ.AL[i, j])
         VR = rightnull!(_transpose_tail(ψ.AR[i, j + 1]))
-        intermediate = adjoint(VL) * AC2 * adjoint(VR)
+        intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, V, = tsvd!(intermediate; trunc=alg.trscheme, alg=alg.alg_svd)
 
         AL′[i, j] = VL * U
@@ -87,7 +87,7 @@ function changebonds!(ψ::AbstractFiniteMPS, H, alg::OptimalExpand, envs=environ
         NR = rightnull!(_transpose_tail(ψ.AR[i + 1]))
 
         #Use this nullspaces and SVD decomposition to determine the optimal expansion space
-        intermediate = adjoint(NL) * AC2 * adjoint(NR)
+        intermediate = normalize!(adjoint(NL) * AC2 * adjoint(NR))
         _, _, V, = tsvd!(intermediate; trunc=alg.trscheme, alg=alg.alg_svd)
 
         ar_re = V * NR

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -28,7 +28,7 @@ function changebonds(ψ::InfiniteMPS, alg::RandExpand)
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = leftnull(ψ.AL[i])
         VR = rightnull!(_transpose_tail(ψ.AR[i + 1]))
-        intermediate = adjoint(VL) * AC2 * adjoint(VR)
+        intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, V, = tsvd!(intermediate; trunc=alg.trscheme, alg=alg.alg_svd)
 
         AL′[i] = VL * U
@@ -52,7 +52,7 @@ function changebonds!(ψ::AbstractFiniteMPS, alg::RandExpand)
         NR = rightnull!(_transpose_tail(ψ.AR[i + 1]))
 
         #Use this nullspaces and SVD decomposition to determine the optimal expansion space
-        intermediate = adjoint(NL) * AC2 * adjoint(NR)
+        intermediate = normalize!(adjoint(NL) * AC2 * adjoint(NR))
         _, _, V, = tsvd!(intermediate; trunc=alg.trscheme, alg=alg.alg_svd)
 
         ar_re = V * NR


### PR DESCRIPTION
This PR changes the `changebonds` implementations to first normalize before computing the truncated SVD.
As we are not using the resulting `S`, this effectively has no influence on truncations like `truncdim`, however for `truncbelow` this will now truncate a normalized spectrum, therefore being a bit more "scale-invariant".
Effectively, this is manually converting the absolute truncation schemes defined in TensorKit to relative ones.