### PR TITLE
Fix MPO copy issue of #288

### DIFF
--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -55,7 +55,8 @@ DenseMPO(mpo::MPO) = mpo isa DenseMPO ? copy(mpo) : MPO(map(TensorMap, parent(mp
 Base.parent(mpo::MPO) = mpo.O
 Base.copy(mpo::MPO) = MPO(map(copy, mpo))
 
-Base.copy(mpo::FiniteMPO) = FiniteMPO(map(copy, mpo)) # Explicitly split up Finite and Infinite to ensure proper type after copy
+# Explicitly split up Finite and Infinite to ensure proper type after copy
+Base.copy(mpo::FiniteMPO) = FiniteMPO(map(copy, mpo))
 Base.copy(mpo::InfiniteMPO) = InfiniteMPO(map(copy, mpo))
 
 function Base.similar(mpo::MPO{<:MPOTensor}, ::Type{O}, L::Int) where {O<:MPOTensor}

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -55,6 +55,9 @@ DenseMPO(mpo::MPO) = mpo isa DenseMPO ? copy(mpo) : MPO(map(TensorMap, parent(mp
 Base.parent(mpo::MPO) = mpo.O
 Base.copy(mpo::MPO) = MPO(map(copy, mpo))
 
+Base.copy(mpo::FiniteMPO) = FiniteMPO(map(copy, mpo)) # Explicitly split up Finite and Infinite to ensure proper type after copy
+Base.copy(mpo::InfiniteMPO) = InfiniteMPO(map(copy, mpo))
+
 function Base.similar(mpo::MPO{<:MPOTensor}, ::Type{O}, L::Int) where {O<:MPOTensor}
     return MPO(similar(parent(mpo), O, L))
 end

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -53,11 +53,7 @@ DenseMPO(mpo::MPO) = mpo isa DenseMPO ? copy(mpo) : MPO(map(TensorMap, parent(mp
 # Utility
 # -------
 Base.parent(mpo::MPO) = mpo.O
-Base.copy(mpo::MPO) = MPO(map(copy, mpo))
-
-# Explicitly split up Finite and Infinite to ensure proper type after copy
-Base.copy(mpo::FiniteMPO) = FiniteMPO(map(copy, mpo))
-Base.copy(mpo::InfiniteMPO) = InfiniteMPO(map(copy, mpo))
+Base.copy(mpo::MPO) = MPO(copy.(parent(mpo)))
 
 function Base.similar(mpo::MPO{<:MPOTensor}, ::Type{O}, L::Int) where {O<:MPOTensor}
     return MPO(similar(parent(mpo), O, L))

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -508,4 +508,18 @@ end
     @test expectation_value(psi2, O) ≈ dot(psi, psi2) * dot(psi2, psi)
 end
 
+@testset "MPO copy behaviour" begin
+    # testset that checks the fix for issue #288
+    H = transverse_field_ising()
+    O = make_time_mpo(H, 0.1, TaylorCluster(2, true, true))
+    FO = open_boundary_conditions(O, 4)
+    FH = open_boundary_conditions(H, 4)
+
+    # check if the copy of the MPO is the same type as the original
+    @test typeof(copy(O)) == typeof(O)
+    @test typeof(copy(FO)) == typeof(FO)
+    @test typeof(copy(H)) == typeof(H)
+    @test typeof(copy(FH)) == typeof(FH)
+end
+
 end


### PR DESCRIPTION
This PR implements 2 explicit `copy` implementations for both `FiniteMPO` and `InfiniteMPO` to ensure the type of the output is the same as the original MPO.

I also implemented some small test to ensure this behaviour in the future making sure #288 does not return in the future.