### PR TITLE
[Feature] FiniteMPOHamiltonian compression

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -115,6 +115,7 @@ include("operators/abstractmpo.jl")
 include("operators/mpo.jl")
 include("operators/jordanmpotensor.jl")
 include("operators/mpohamiltonian.jl") # the mpohamiltonian objects
+include("operators/ortho.jl")
 include("operators/multilinempo.jl")
 include("operators/projection.jl")
 include("operators/timedependence.jl")

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -105,3 +105,21 @@ end
 function changebonds(ψ, H, alg::SvdCut, envs = environments(ψ, H))
     return changebonds(ψ, alg), envs
 end
+
+function changebonds!(H::FiniteMPOHamiltonian, alg::SvdCut)
+    # orthogonality center to the left
+    for i in length(H):-1:2
+        H = right_canonicalize!(H, i)
+    end
+
+    # swipe right
+    for i in 1:(length(H) - 1)
+        H = left_canonicalize!(H, i; alg = alg.alg_svd, alg.trscheme)
+    end
+    # swipe left -- TODO: do we really need this double sweep?
+    for i in length(H):-1:2
+        H = right_canonicalize!(H, i; alg = alg.alg_svd, alg.trscheme)
+    end
+
+    return H
+end

--- a/src/operators/jordanmpotensor.jl
+++ b/src/operators/jordanmpotensor.jl
@@ -72,16 +72,16 @@ function JordanMPOTensor(
     ) where {E, S, TA, TB, TC, TD}
     allVs = eachspace(V)
     VA = space(allVs[2:(end - 1), 1, 1, 2:(end - 1)])
-    VA == space(A) || throw(SpaceMismatch("A-block has incompatible spaces"))
+    VA == space(A) || throw(SpaceMismatch(lazy"A-block has incompatible spaces:\n$VA\n$(space(A))"))
 
     VB = removeunit(space(allVs[2:(end - 1), 1, 1, end]), 4)
-    VB == space(B) || throw(SpaceMismatch("B-block has incompatible spaces"))
+    VB == space(B) || throw(SpaceMismatch(lazy"B-block has incompatible spaces:\n$VB\n$(space(B))"))
 
     VC = removeunit(space(allVs[1, 1, 1, 2:(end - 1)]), 1)
-    VC == space(C) || throw(SpaceMismatch("C-block has incompatible spaces"))
+    VC == space(C) || throw(SpaceMismatch(lazy"C-block has incompatible spaces:\n$VC\n$(space(C))"))
 
     VD = removeunit(removeunit(space(allVs[1, 1, 1, end:end]), 4), 1)
-    VD == space(D) || throw(SpaceMismatch("D-block has incompatible spaces"))
+    VD == space(D) || throw(SpaceMismatch(lazy"D-block has incompatible spaces:\n$VD\n$(space(D))"))
 
     return JordanMPOTensor{E, S, TA, TB, TC, TD}(V, A, B, C, D)
 end

--- a/src/operators/jordanmpotensor.jl
+++ b/src/operators/jordanmpotensor.jl
@@ -67,10 +67,8 @@ end
 
 function JordanMPOTensor(
         V::TensorMapSumSpace{S, 2, 2},
-        A::SparseBlockTensorMap{TA, E, S, 2, 2},
-        B::SparseBlockTensorMap{TB, E, S, 2, 1},
-        C::SparseBlockTensorMap{TC, E, S, 1, 2},
-        D::SparseBlockTensorMap{TD, E, S, 1, 1}
+        A::SparseBlockTensorMap{TA, E, S, 2, 2}, B::SparseBlockTensorMap{TB, E, S, 2, 1},
+        C::SparseBlockTensorMap{TC, E, S, 1, 2}, D::SparseBlockTensorMap{TD, E, S, 1, 1}
     ) where {E, S, TA, TB, TC, TD}
     allVs = eachspace(V)
     VA = space(allVs[2:(end - 1), 1, 1, 2:(end - 1)])
@@ -86,6 +84,18 @@ function JordanMPOTensor(
     VD == space(D) || throw(SpaceMismatch("D-block has incompatible spaces"))
 
     return JordanMPOTensor{E, S, TA, TB, TC, TD}(V, A, B, C, D)
+end
+function JordanMPOTensor(
+        V::TensorMapSumSpace{S, 2, 2},
+        A::AbstractTensorMap{E, S, 2, 2}, B::AbstractTensorMap{E, S, 2, 1},
+        C::AbstractTensorMap{E, S, 1, 2}, D::AbstractTensorMap{E, S, 1, 1}
+    ) where {E, S}
+    return JordanMPOTensor(V,
+        A isa SparseBlockTensorMap ? A : SparseBlockTensorMap(A),
+        B isa SparseBlockTensorMap ? B : SparseBlockTensorMap(B),
+        C isa SparseBlockTensorMap ? C : SparseBlockTensorMap(C),
+        D isa SparseBlockTensorMap ? D : SparseBlockTensorMap(D)
+    )
 end
 
 function JordanMPOTensor(W::SparseBlockTensorMap{TT, E, S, 2, 2}) where {TT, E, S}

--- a/src/operators/ortho.jl
+++ b/src/operators/ortho.jl
@@ -1,16 +1,18 @@
-function TensorKit.leftorth!(W::JordanMPOTensor; alg = QRpos())
+function TensorKit.leftorth(W::JordanMPOTensor; alg = QRpos())
     # orthogonalize second column against first
     WI = removeunit(W[1, 1, 1, 1], 1)
     @tensor t[l; r] := conj(WI[p; p' l]) * W.C[p; p' r]
     I = sectortype(W)
     S = spacetype(W)
 
-    @tensor t[l; r] := conj(removeunit(W[1, 1, 1, 1], 1)[p; p' l]) * W.C[p; p' r]
-    @tensor C′[p; p' r] := W.C[p; p' r] - WI[p; p' l] * t[l; r]
+    @plansor t[l; r] := conj(removeunit(W[1, 1, 1, 1], 1)[p; p' l]) * W.C[p; p' r]
+    # @plansor C′[p; p' r] := W.C[p; p' r] - WI[p; p' l] * t[l; r]
+    @plansor C′[p; p' r] := -WI[p; p' l] * t[l; r]
+    add!(C′, W.C)
 
     # QR of second column
-    CA = cat(insertleftunit(C′, 1), W.A; dims = 1)
-    Q, r = leftorth(CA, ((3, 1, 2), (4,)); alg)
+    CA = transpose(cat(insertleftunit(C′, 1), W.A; dims = 1), ((3, 1, 2), (4,)))
+    Q, r = leftorth!(CA; alg)
     Q′ = transpose(Q, ((2, 3), (1, 4)))
     V = codomain(W) ← physicalspace(W) ⊗ BlockTensorKit.oplus(oneunit(S), right_virtualspace(Q′), oneunit(S))
     Q1 = SparseBlockTensorMap(Q′[2:end, 1, 1, 1])
@@ -26,4 +28,38 @@ function TensorKit.leftorth!(W::JordanMPOTensor; alg = QRpos())
     R[3, 3] = id!(R[3, 3])
 
     return W′, R
+end
+
+function left_canonicalize!(H::MPOHamilonian, i::Int; alg = QRPos())
+    @assert i != 1 "TBA"
+
+    W = H[i]
+
+    # orthogonalize second column against first
+    WI = removeunit(W[1, 1, 1, 1], 1)
+    @tensor t[l; r] := conj(WI[p; p' l]) * W.C[p; p' r]
+    # @plansor C′[p; p' r] := W.C[p; p' r] - WI[p; p' l] * t[l; r]
+    @plansor C′[p; p' r] := -WI[p; p' l] * t[l; r]
+    add!(C′, W.C)
+
+    # QR of second column
+    CA = transpose(cat(insertleftunit(C′, 1), W.A; dims = 1), ((3, 1, 2), (4,)))
+    Q, R = leftorth!(CA; alg)
+    Q′ = transpose(Q, ((2, 3), (1, 4)))
+    Q1 = SparseBlockTensorMap(Q′[2:end, 1, 1, 1])
+    Q2 = removeunit(SparseBlockTensorMap(Q′[1:1, 1, 1, 1]), 1)
+    V = BlockTensorKit.oplus(oneunit(spacetype(W)), right_virtualspace(Q′), oneunit(spacetype(W)))
+    H[i] = JordanMPOTensor(codomain(W) ← physicalspace(W) ⊗ V, Q1, W.B, Q2, W.D)
+
+    # absorb into next site
+    W′ = H[i + 1]
+    @plansor A′[l p; p' r] := R[l; r'] * W′.A[r' p; p' r]
+    @plansor B′[l p; p'] := R[l; r] * W′.B[r p; p']
+    @plansor C′[l p; p' r] := t[l; r'] * W′.A[r' p; p' r]
+    C′ = add!(removeunit(C, 1), W′.C)
+    @plansor D′[l p; p'] := t[l; r] * W′.B[r p; p']
+    D′ = add!(removeunit(D, 1), W′.D)
+
+    H[i + 1] = JordanMPOTensor(V ⊗ physicalspace(W′) ← domain(W′), A′, B′, C′, D′)
+    return H
 end

--- a/src/operators/ortho.jl
+++ b/src/operators/ortho.jl
@@ -63,3 +63,36 @@ function left_canonicalize!(H::MPOHamilonian, i::Int; alg = QRPos())
     H[i + 1] = JordanMPOTensor(V ⊗ physicalspace(W′) ← domain(W′), A′, B′, C′, D′)
     return H
 end
+
+function right_canonicalize!(H::MPOHamilonian, i::Int; alg = RQpos())
+    @assert i != length(H) "TBA"
+
+    W = H[i]
+
+    # orthogonalize second row against last
+    WI = removeunit(W[end, 1, 1, end], 4)
+    @tensor t[l; r] := conj(WI[r p; p']) * W.B[l p; p']
+    @plansor B′[l p; p'] := -WI[r p; p'] * t[l; r]
+    add!(B′, W.B)
+
+    # LQ of second row
+    AB = transpose(cat(insertleftunit(B′, 4), W.A; dims = 4), ((1,), (3, 4, 2)))
+    R, Q = rightorth!(AB; alg)
+    Q′ = transpose(Q, ((1, 4), (2, 3)))
+    Q1 = SparseBlockTensorMap(Q′[1, 1, 1, 2:end])
+    Q2 = removeunit(SparseBlockTensorMap(Q′[1:1, 1, 1, 1]), 4)
+    V = BlockTensorKit.oplus(oneunit(spacetype(W)), left_virtualspace(Q′), oneunit(spacetype(W)))
+    H[i] = JordanMPOTensor(V ⊗ physicalspace(W) ← domain(W), Q1, Q2, W.C, W.D)
+
+    # absorb into previous site
+    W′ = H[i - 1]
+    @plansor A′[l p; p' r] := W′.A[l p; p' r] * R[r; r] 
+    @plansor B′[l p; p' r'] := W′.A[l p; p' r'] * t[r'; r] R[l; r] * W′.B[r p; p']
+    B′ = add!(removeunit(B′, 4), W′.B)
+    @plansor C′[p; p' r] := W′.C[p; p' r'] * R[r'; r]
+    @plansor D′[p; p' r] := W′.C[p; p' l] *t[l; r]  
+    D′ = add!(removeunit(D, 3), W′.D)
+
+    H[i - 1] = JordanMPOTensor(V ⊗ physicalspace(W′) ← domain(W′), A′, B′, C′, D′)
+    return H
+end

--- a/src/operators/ortho.jl
+++ b/src/operators/ortho.jl
@@ -1,0 +1,29 @@
+function TensorKit.leftorth!(W::JordanMPOTensor; alg = QRpos())
+    # orthogonalize second column against first
+    WI = removeunit(W[1, 1, 1, 1], 1)
+    @tensor t[l; r] := conj(WI[p; p' l]) * W.C[p; p' r]
+    I = sectortype(W)
+    S = spacetype(W)
+
+    @tensor t[l; r] := conj(removeunit(W[1, 1, 1, 1], 1)[p; p' l]) * W.C[p; p' r]
+    @tensor C′[p; p' r] := W.C[p; p' r] - WI[p; p' l] * t[l; r]
+
+    # QR of second column
+    CA = cat(insertleftunit(C′, 1), W.A; dims = 1)
+    Q, r = leftorth(CA, ((3, 1, 2), (4,)); alg)
+    Q′ = transpose(Q, ((2, 3), (1, 4)))
+    V = codomain(W) ← physicalspace(W) ⊗ BlockTensorKit.oplus(oneunit(S), right_virtualspace(Q′), oneunit(S))
+    Q1 = SparseBlockTensorMap(Q′[2:end, 1, 1, 1])
+    Q2 = removeunit(SparseBlockTensorMap(Q′[1:1, 1, 1, 1]), 1)
+
+    # Assemble output
+    W′ = JordanMPOTensor(V, Q1, W.B, Q2, W.D)
+
+    R = similar(W, right_virtualspace(W′) ← right_virtualspace(W′))
+    R[1, 1] = id!(R[1, 1])
+    R[1, 2] = t
+    R[2, 2] = r
+    R[3, 3] = id!(R[3, 3])
+
+    return W′, R
+end

--- a/src/operators/ortho.jl
+++ b/src/operators/ortho.jl
@@ -88,10 +88,15 @@ function left_canonicalize!(
 
     # absorb into next site
     W′ = H[i + 1]
-    @plansor A′[l p; p' r] := R[l; r'] * W′.A[r' p; p' r]
+    if i != length(H) - 1
+        @plansor A′[l p; p' r] := R[l; r'] * W′.A[r' p; p' r]
+        @plansor C′[l p; p' r] := t[l; r'] * W′.A[r' p; p' r]
+        C′ = add!(removeunit(C′, 1), W′.C)
+    else
+        A′ = similar(W′.A, space(R, 1) ⊗ physicalspace(W′) ← domain(W′.A))
+        C′ = W′.C
+    end
     @plansor B′[l p; p'] := R[l; r] * W′.B[r p; p']
-    @plansor C′[l p; p' r] := t[l; r'] * W′.A[r' p; p' r]
-    C′ = add!(removeunit(C′, 1), W′.C)
     @plansor D′[l p; p'] := t[l; r] * W′.B[r p; p']
     D′ = add!(removeunit(D′, 1), W′.D)
 
@@ -101,7 +106,7 @@ end
 
 function right_canonicalize!(
         H::MPOHamiltonian, i::Int;
-        alg = RQpos(), trscheme::TruncationScheme = notrunc()
+        alg = LQpos(), trscheme::TruncationScheme = notrunc()
     )
     if H isa FiniteMPOHamiltonian
         1 < i ≤ length(H) || throw(ArgumentError("Bounds error in canonicalize"))
@@ -156,9 +161,14 @@ function right_canonicalize!(
 
     # absorb into previous site
     W′ = H[i - 1]
-    @plansor A′[l p; p' r] := W′.A[l p; p' r'] * R[r'; r]
-    @plansor B′[l p; p' r] := W′.A[l p; p' r'] * t[r'; r]
-    B′ = add!(removeunit(B′, 4), W′.B)
+    if i != 2
+        @plansor A′[l p; p' r] := W′.A[l p; p' r'] * R[r'; r]
+        @plansor B′[l p; p' r] := W′.A[l p; p' r'] * t[r'; r]
+        B′ = add!(removeunit(B′, 4), W′.B)
+    else
+        A′ = similar(W′.A, codomain(W′.A) ← physicalspace(W′.A) ⊗ space(R, 2)')
+        B′ = W′.B
+    end
     @plansor C′[p; p' r] := W′.C[p; p' r'] * R[r'; r]
     @plansor D′[p; p' r] := W′.C[p; p' r'] * t[r'; r]
     D′ = add!(removeunit(D′, 3), W′.D)


### PR DESCRIPTION
This is an implementation of the algorithm described in [Parker et al](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.102.035147), which allows compression of MPOHamiltonian objects without ruining the `JordanMPOTensor` structure.
There are still some questions about implementation details, tests and docs, and I would like to at least at the reference somewhere before merging, but I already wanted to add this here so people might start playing around with it.
Also, I would like to add the infinite version as well.

Importantly, this keeps the `JordanMPOTensor` structure but ruins the sparsity, so this is not in general something we always want to do. However, especially when working with quasi-2D systems, often terms of the form `XiXi+1` and `X_iX_i+L` appear and can be efficiently compressed, which is not something that our MPO construction scheme would naturally do.

See also #311 