### PR TITLE
Remove IDMRG logging incorrect energy

### DIFF
--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -63,13 +63,13 @@ function find_groundstate(ost::InfiniteMPS, H, alg::IDMRG, envs = environments(o
             ϵ = norm(C_current - ψ.C[0])
 
             if ϵ < alg.tol
-                @infov 2 logfinish!(log, iter, ϵ, expectation_value(ψ, H, envs))
+                @infov 2 logfinish!(log, iter, ϵ)
                 break
             end
             if iter == alg.maxiter
-                @warnv 1 logcancel!(log, iter, ϵ, expectation_value(ψ, H, envs))
+                @warnv 1 logcancel!(log, iter, ϵ)
             else
-                @infov 3 logiter!(log, iter, ϵ, expectation_value(ψ, H, envs))
+                @infov 3 logiter!(log, iter, ϵ)
             end
         end
     end


### PR DESCRIPTION
During the IDMRG iterations, the objective which is supposed to represent the expectation value of the Hamiltonian is completely incorrect. This is because the environment only gets recalculated with `recalculate!` at the end of the sweeps, so these intermediate values are irrelevant. 

I chose to remove showing these values, but another option is to calculate the expectation value without passing the environments, thus recalculating at every step. I don't know how costly this step is, so I chose to do it like in `IDMRG2`.