### PR TITLE
Small fixes

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "yas"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
-
-- repo: https://github.com/qiaojunfeng/pre-commit-julia-format
-  rev: v0.2.0                # use the most recent version
-  hooks:
-  - id: julia-format         # formatter for Julia code

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   orcid: "https://orcid.org/0000-0002-0858-291X"
 
 title: "MPSKit"
-version: 0.10.2
-doi: 10.5281/zenodo.10654901
-date-released: 2024-02-13
+version: 0.13.5
+doi: 10.5281/zenodo.17065473
+date-released: 2025-09-05
 url: "https://github.com/QuantumKitHub/MPSKit.jl"

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ and matrix product operators (MPO), both finite and infinite.
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://QuantumKitHub.github.io/MPSKit.jl/dev
 
-[doi-img]: https://zenodo.org/badge/DOI/10.5281/zenodo.10654901.svg
-[doi-url]: https://doi.org/10.5281/zenodo.10654901
+[doi-img]: https://zenodo.org/badge/DOI/10.5281/zenodo.17065473.svg
+[doi-url]: https://doi.org/10.5281/zenodo.17065473
 
 [codecov-img]: https://codecov.io/gh/QuantumKitHub/MPSKit.jl/branch/master/graph/badge.svg?token=rmp3bu7qn3
 [codecov-url]: https://codecov.io/gh/QuantumKitHub/MPSKit.jl


### PR DESCRIPTION
This PR implements 2 small fixes:
1. Removes the 2 files that were related to the YAS style formatting that has been abandoned in favor of runic in #303 .
2. Update the Citation file, along with the DOI in this file and the DOI in the readme.

A different DOI is associated with every release, which is rather cumbersome but since the one in the citation file and the readme was from MPSKit 0.10 I figured an update was needed.