### PR TITLE
Add pre-commit hook for Runic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/fredrikekre/runic-pre-commit
+    rev: v2.0.1
+    hooks:
+      - id: runic


### PR DESCRIPTION
Creates a pre-commit hook to ensure that Runic is enforced before every commit. By default, this file does nothing, so users cloning MPSKit that want to use this feature should:
- have pre-commit installed on their system
- run `pre-commit install` to enable the git-hooks

See also https://pre-commit.com for installation instructions