### PR TITLE
`local_expectation_value` function

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -42,7 +42,7 @@ export DynamicalDMRG, NaiveInvert, Jeckelmann
 export exact_diagonalization, fidelity_susceptibility
 
 # toolbox:
-export expectation_value, correlator, variance
+export expectation_value, local_expectation_value, correlator, variance
 export correlation_length, marek_gap, transfer_spectrum
 export entropy, entanglement_spectrum
 export open_boundary_conditions, periodic_boundary_conditions

--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -119,6 +119,26 @@ function local_expectation_value(
     )
 end
 
+# MPO tensor
+#-----------
+function expectation_value(
+        ψ::InfiniteMPS, O::MPOTensor,
+        envs::AbstractMPSEnvironments
+    )
+    return sum(1:length(ψ)) do site
+        return local_expectation_value(ψ, O, envs, site)
+    end
+end
+
+function local_expectation_value(
+        ψ::InfiniteMPS, O::MPOTensor,
+        envs::AbstractMPSEnvironments, site::Int=1
+    )
+    return contract_mpo_expval(
+        ψ.AC[site], envs.GLs[site], O, envs.GRs[site]
+    )
+end
+
 # DenseMPO
 # --------
 function expectation_value(ψ::FiniteMPS, mpo::FiniteMPO)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -480,7 +480,7 @@ module TestAlgorithms
         O = ising_bulk_tensor(beta)
         denom = expectation_value(ψ, O, envs)
         
-        M = ising_magnetization_tensor(beta)
+        M = ising_magnetisation_tensor(beta)
         m = local_expectation_value(ψ, M, envs) / denom
         @test m ≈ m_th atol = 1.0e-10
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -462,6 +462,33 @@ module TestAlgorithms
         end
     end
 
+    @testset "2D infinite partition functions" verbose = true begin
+        beta = 0.5 # ferromagnetic phase
+        f_th = -2.0515856253898357
+        m_th = 0.911319377877496
+        e_th = -1.7455645753125533
+
+        alg = VOMPS(; tol=1e-8, verbosity=verbosity_conv)
+        O_mpo = classical_ising(; β = beta)
+        ψ₀ = InfiniteMPS(ℂ^2, ℂ^10)
+        ψ, envs = leading_boundary(ψ₀, O_mpo, alg)
+
+        λ = expectation_value(ψ, O_mpo, envs)
+        f = -log(λ) / beta
+        @test f ≈ f_th atol = 1.0e-10
+
+        O = ising_bulk_tensor(beta)
+        denom = expectation_value(ψ, O, envs)
+        
+        M = ising_magnetization_tensor(beta)
+        m = local_expectation_value(ψ, M, envs) / denom
+        @test m ≈ m_th atol = 1.0e-10
+
+        E = ising_energy_tensor(beta)
+        e = local_expectation_value(ψ, E, envs) / denom
+        @test e ≈ e_th atol = 1e-2
+    end
+
     @testset "excitations" verbose = true begin
         @testset "infinite (ham)" begin
             H = repeat(force_planar(heisenberg_XXX()), 2)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -245,8 +245,11 @@ module TestOperators
 
         e1 = expectation_value(ψ2, H1)
         e3 = expectation_value(ψ2, H3)
+        e3_1 = local_expectation_value(ψ2, H3, environments(ψ2, H3), 1)
+        e3_2 = local_expectation_value(ψ2, H3, environments(ψ2, H3), 2)
 
         @test e1 + e3 ≈ expectation_value(ψ2, H1 + H3) atol = 1.0e-10
+        @test e3 ≈ e3_1 + e3_2 atol = 1.0e-10
 
         H4 = H1 + H3
         h4 = H4 * H4

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -19,7 +19,7 @@ export symm_mul_mpo
 export transverse_field_ising, heisenberg_XXX, bilinear_biquadratic_model, XY_model,
     kitaev_model
 export classical_ising, sixvertex
-export ising_bond_tensor, ising_magnetisation_tensor, ising_energy_tensor
+export ising_bond_tensor, ising_bulk_tensor, ising_magnetisation_tensor, ising_energy_tensor
 
 # using TensorOperations
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -323,6 +323,7 @@ end
 
 function ising_energy_tensor(β)
     nt = ising_bond_tensor(β)
+    O = ising_bulk_tensor(β)
     J = 1.0
     e = ComplexF64[-J J; J -J] .* nt
     @tensor e_hor[-1 -2; -3 -4] :=


### PR DESCRIPTION
This PR introduces the function `local_expectation_value`. This was originally meant for in the context of (infinite) partition functions and thus MPO tensors (see #320), but I extended the definition to MPO hamiltonians. 

The local expectation values are currently not normalised in the MPO case (as can be seen in the added tests). I don't know what's the cleanest way to do that, since the environments are not from the MPO tensor itself. I'm open to suggestions. Maybe @VictorVanthilt can chime in, since I'm doing the complementary thing to TNR.

I didn't add anything for the finite case, partly because I don't need it, and mostly because it's annoying to make a test. If it's really wanted, I can look into it, but this won't happen any time soon 🫠.