### PR TITLE
Modify `_totuple`

### DIFF
--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -112,7 +112,7 @@ function randomize!(a::AbstractBlockTensorMap)
     return a
 end
 
-_totuple(t) = t isa Tuple ? t : tuple(t)
+_totuple(t) = t isa Tuple ? t : (t isa Symbol ? tuple(t) : Tuple(t))
 
 """
     tensorexpr(name, ind_out, [ind_in])


### PR DESCRIPTION
This PR catches the edge case `tensorexpr(:name, :i, :j)` so it can be converted to `tensorexpr(:name, (:i,), (:j,))` correctly.
```julia
julia> tuple(:a)
(:a,)

julia> Tuple(:a)
ERROR: MethodError: no method matching length(::Symbol)
The function `length` exists, but no method is defined for this combination of argument types.
...
```
See also https://github.com/QuantumKitHub/PEPSKit.jl/pull/268. 