### PR TITLE
Don't assume `transpose` makes a copy

### DIFF
--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -31,7 +31,7 @@ function changebonds(
 
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = left_null(ψ.AL[i])
-        VR = right_null!(_transpose_tail(ψ.AR[i + 1]))
+        VR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
         intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
@@ -57,7 +57,7 @@ function changebonds(ψ::MultilineMPS, H, alg::OptimalExpand, envs = environment
 
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = left_null(ψ.AL[i, j])
-        VR = right_null!(_transpose_tail(ψ.AR[i, j + 1]))
+        VR = right_null!(_transpose_tail(ψ.AR[i, j + 1]; copy = true))
         intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
@@ -86,7 +86,7 @@ function changebonds!(ψ::AbstractFiniteMPS, H, alg::OptimalExpand, envs = envir
 
         #Calculate nullspaces for left and right
         NL = left_null(ψ.AC[i])
-        NR = right_null!(_transpose_tail(ψ.AR[i + 1]))
+        NR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
 
         #Use this nullspaces and SVD decomposition to determine the optimal expansion space
         intermediate = normalize!(adjoint(NL) * AC2 * adjoint(NR))

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -27,7 +27,7 @@ function changebonds(ψ::InfiniteMPS, alg::RandExpand)
 
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = left_null(ψ.AL[i])
-        VR = right_null!(_transpose_tail(ψ.AR[i + 1]))
+        VR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
         intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
@@ -49,7 +49,7 @@ function changebonds!(ψ::AbstractFiniteMPS, alg::RandExpand)
 
         #Calculate nullspaces for left and right
         NL = left_null(ψ.AC[i])
-        NR = right_null!(_transpose_tail(ψ.AR[i + 1]))
+        NR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
 
         #Use this nullspaces and SVD decomposition to determine the optimal expansion space
         intermediate = normalize!(adjoint(NL) * AC2 * adjoint(NR))

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -57,7 +57,7 @@ function find_groundstate(ost::InfiniteMPS, H, alg::IDMRG, envs = environments(o
                 h = AC_hamiltonian(pos, ψ, H, ψ, envs)
                 _, ψ.AC[pos] = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
 
-                ψ.C[pos - 1], temp = right_orth!(_transpose_tail(ψ.AC[pos]))
+                ψ.C[pos - 1], temp = right_orth!(_transpose_tail(ψ.AC[pos]; copy = (pos == 1)))
                 ψ.AR[pos] = _transpose_front(temp)
 
                 transfer_rightenv!(envs, ψ, H, ψ, pos - 1)

--- a/src/states/orthoview.jl
+++ b/src/states/orthoview.jl
@@ -60,7 +60,7 @@ function Base.getindex(v::CView{<:FiniteMPS, E}, i::Int)::E where {E}
         end
 
         for j in Iterators.reverse((i + 1):center)
-            v.parent.Cs[j], tmp = lq_compact!(_transpose_tail(v.parent.ACs[j]); positive = true)
+            v.parent.Cs[j], tmp = lq_compact!(_transpose_tail(v.parent.ACs[j]; copy = true); positive = true)
             v.parent.ARs[j] = _transpose_front(tmp)
             if j != i + 1 # last AC not needed
                 v.parent.ACs[j - 1] = _mul_tail(v.parent.ALs[j - 1], v.parent.Cs[j])
@@ -89,7 +89,7 @@ end
 function Base.setindex!(v::CView{<:FiniteMPS}, vec, i::Int)
     if ismissing(v.parent.Cs[i + 1])
         if !ismissing(v.parent.ALs[i])
-            v.parent.Cs[i + 1], temp = lq_compact!(_transpose_tail(v.parent.AC[i + 1]); positive = true)
+            v.parent.Cs[i + 1], temp = lq_compact!(_transpose_tail(v.parent.AC[i + 1]; copy = true); positive = true)
             v.parent.ARs[i + 1] = _transpose_front(temp)
         else
             v.parent.ALs[i], v.parent.Cs[i + 1] = qr_compact(v.parent.AC[i]; positive = true)

--- a/src/states/quasiparticle_state.jl
+++ b/src/states/quasiparticle_state.jl
@@ -73,7 +73,7 @@ function RightGaugedQP(
     )
     # find the left null spaces for the TNS
     excitation_space = Vect[typeof(sector)](sector => 1)
-    VRs = convert(Vector, map(right_null! ∘ _transpose_tail, right_gs.AR))
+    VRs = convert(Vector, map(x -> right_null!(_transpose_tail(x; copy = true)), right_gs.AR))
     Xs = map(enumerate(VRs)) do (i, vr)
         x = similar(
             vr,

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -1,11 +1,11 @@
-function _transpose_front(t::AbstractTensorMap) # make TensorMap{S,N₁+N₂-1,1}
-    return repartition(t, numind(t) - 1, 1)
+function _transpose_front(t::AbstractTensorMap; copy::Bool = false)
+    return repartition(t, numind(t) - 1, 1; copy)
 end
-function _transpose_tail(t::AbstractTensorMap) # make TensorMap{S,1,N₁+N₂-1}
-    return repartition(t, 1, numind(t) - 1)
+function _transpose_tail(t::AbstractTensorMap; copy::Bool = false) # make TensorMap{S,1,N₁+N₂-1}
+    return repartition(t, 1, numind(t) - 1; copy)
 end
-function _transpose_as(t1::AbstractTensorMap, t2::AbstractTensorMap)
-    return repartition(t1, numout(t2), numin(t2))
+function _transpose_as(t1::AbstractTensorMap, t2::AbstractTensorMap; copy::Bool = false)
+    return repartition(t1, numout(t2), numin(t2); copy)
 end
 
 _mul_front(C, A) = _transpose_front(C * _transpose_tail(A))
@@ -28,7 +28,7 @@ function decompose_localmpo(
 
     leftind = (N + 1, 1, 2)
     rightind = (ntuple(x -> x + N + 1, N - 1)..., reverse(ntuple(x -> x + 2, N - 2))...)
-    V, C = left_orth!(transpose(inpmpo, (leftind, rightind)); trunc)
+    V, C = left_orth!(transpose(inpmpo, (leftind, rightind); copy = true); trunc)
 
     A = transpose(V, ((2, 3), (1, 4)))
     B = transpose(C, ((1, reverse(ntuple(x -> x + N, N - 2))...), ntuple(x -> x + 1, N - 1)))
@@ -43,7 +43,7 @@ function decompose_localmps(
 
     leftind = (1, 2)
     rightind = reverse(ntuple(x -> x + 2, N - 1))
-    A, C = left_orth!(transpose(state, (leftind, rightind)); trunc)
+    A, C = left_orth!(transpose(state, (leftind, rightind); copy = true); trunc)
     B = _transpose_front(C)
     return [A; decompose_localmps(B)]
 end


### PR DESCRIPTION
Here I address a range of subtle bugs that were already there and some new ones that got introduced when the TensorKit update happened.
The primary problem is that we shouldn't assume that `transpose` or any of its variants produces independent data. Obvious offenders were e.g. `qr_compact!(repartition(t, 2, 2))`, which isn't guaranteed to not alter `t`.

The problem wasn't caught before because in most cases, a copy has to be made anyways (e.g. when there are symmetries involved, or for most array sizes), but after a bug report by @20akshay00 the issue shows itself when working with product states, since there `1xdx1` arrays can always trivially be permuted without copies.

I hope that I caught all of the cases here, but it's a bit hard to test this in general since some of the algorithms seem to even be somewhat robust against these kinds of issues.