### PR TITLE
add AbstractInfiniteMPS

### DIFF
--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -2,18 +2,18 @@
     expectation_value(ψ, O, [environments])
     expectation_value(ψ, inds => O)
 
-Compute the expectation value of an operator `O` on a state `ψ`. 
+Compute the expectation value of an operator `O` on a state `ψ`.
 Optionally, it is possible to make the computations more efficient by also passing in
 previously calculated `environments`.
 
 In general, the operator `O` may consist of an arbitrary MPO `O <: AbstractMPO` that acts
-on all sites, or a local operator `O = inds => operator` acting on a subset of sites. 
+on all sites, or a local operator `O = inds => operator` acting on a subset of sites.
 In the latter case, `inds` is a tuple of indices that specify the sites on which the operator
 acts, while the operator is either a `AbstractTensorMap` or a `FiniteMPO`.
 
 # Arguments
 * `ψ::AbstractMPS` : the state on which to compute the expectation value
-* `O::Union{AbstractMPO,Pair}` : the operator to compute the expectation value of. 
+* `O::Union{AbstractMPO,Pair}` : the operator to compute the expectation value of.
     This can either be an `AbstractMPO`, or a pair of indices and local operator..
 * `environments::AbstractMPSEnvironments` : the environments to use for the calculation. If not given, they will be calculated.
 
@@ -125,7 +125,7 @@ function expectation_value(
 end
 
 function expectation_value(
-        ψ::InfiniteMPS, H::InfiniteMPOHamiltonian,
+        ψ::AbstractInfiniteMPS, H::InfiniteMPOHamiltonian,
         envs::AbstractMPSEnvironments = environments(ψ, H)
     )
     return sum(1:length(ψ)) do i
@@ -143,7 +143,7 @@ end
 function expectation_value(ψ::FiniteQP, mpo::FiniteMPO)
     return expectation_value(convert(FiniteMPS, ψ), mpo)
 end
-function expectation_value(ψ::InfiniteMPS, mpo::InfiniteMPO, envs...)
+function expectation_value(ψ::AbstractInfiniteMPS, mpo::InfiniteMPO, envs...)
     return expectation_value(convert(MultilineMPS, ψ), convert(MultilineMPO, mpo), envs...)
 end
 function expectation_value(

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -26,7 +26,7 @@ function find_groundstate(
         tol = Defaults.tol, maxiter = Defaults.maxiter,
         verbosity = Defaults.verbosity, trscheme = nothing
     )
-    if isa(ψ, InfiniteMPS)
+    if isa(ψ, AbstractInfiniteMPS)
         alg = VUMPS(; tol = max(1.0e-4, tol), verbosity, maxiter)
         if tol < 1.0e-4
             alg = alg & GradientGrassmann(; tol = tol, maxiter, verbosity)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -131,7 +131,7 @@ $(TYPEDFIELDS)
     trscheme::TruncationStrategy
 end
 
-function find_groundstate(ost::InfiniteMPS, H, alg::IDMRG2, envs = environments(ost, H))
+function find_groundstate(ost::T, H, alg::IDMRG2, envs = environments(ost, H)) where {T <: AbstractInfiniteMPS}
     length(ost) < 2 && throw(ArgumentError("unit cell should be >= 2"))
     ϵ::Float64 = calc_galerkin(ost, H, ost, envs)
 
@@ -244,7 +244,7 @@ function find_groundstate(ost::InfiniteMPS, H, alg::IDMRG2, envs = environments(
     end
 
     alg_gauge = updatetol(alg.alg_gauge, iter, ϵ)
-    ψ′ = InfiniteMPS(ψ.AR[1:end]; alg_gauge.tol, alg_gauge.maxiter)
+    ψ′ = T(ψ.AR[1:end]; alg_gauge.tol, alg_gauge.maxiter)
     recalculate!(envs, ψ′, H, ψ′)
 
     return ψ′, envs, ϵ

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -46,7 +46,7 @@ struct VUMPSState{S, O, E}
 end
 
 function find_groundstate(
-        mps::InfiniteMPS, operator, alg::VUMPS, envs = environments(mps, operator)
+        mps::AbstractInfiniteMPS, operator, alg::VUMPS, envs = environments(mps, operator)
     )
     return dominant_eigsolve(operator, mps, alg, envs; which = :SR)
 end

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -1,5 +1,6 @@
+abstract type AbstractInfiniteMPS <: AbstractMPS end
 """
-    InfiniteMPS{A<:GenericMPSTensor,B<:MPSBondTensor} <: AbtractMPS
+    InfiniteMPS{A<:GenericMPSTensor,B<:MPSBondTensor} <: AbstractInfiniteMPS
 
 Type that represents an infinite Matrix Product State.
 
@@ -43,7 +44,7 @@ tensors `As`, or a list of left-gauged tensors `ALs`.
 - `tol`: gauge fixing tolerance
 - `maxiter`: gauge fixing maximum iterations
 """
-struct InfiniteMPS{A <: GenericMPSTensor, B <: MPSBondTensor} <: AbstractMPS
+struct InfiniteMPS{A <: GenericMPSTensor, B <: MPSBondTensor} <: AbstractInfiniteMPS
     AL::PeriodicVector{A}
     AR::PeriodicVector{A}
     C::PeriodicVector{B}


### PR DESCRIPTION
In this pull request, I add the abstract type `AbstractInfiniteMPS` and overload the relevant functions for me.
The reason for this abstraction is that I can then define my own `InfiniteMPS` type, which allows me to overload the `getindex` and `setindex!` functions such that they are compatible with MPI without any changes to the algorithms.