### PR TITLE
Fix getproperty function in iterativesolvers.jl

### DIFF
--- a/src/utility/iterativesolvers.jl
+++ b/src/utility/iterativesolvers.jl
@@ -7,7 +7,7 @@ mutable struct IterativeSolver{A, B}
 end
 
 function Base.getproperty(it::IterativeSolver{A, B}, name::Symbol) where {A, B}
-    name === :alg || name === :state && return getfield(it, name)
+    (name === :alg || name === :state) && return getfield(it, name)
 
     alg = getfield(it, :alg)
     name in propertynames(alg) && return getproperty(alg, name)


### PR DESCRIPTION
This PR fixes a tiny mistake in the logic of `Base.getproperty` for the iterative solver type.