### PR TITLE
Allow AbstractArray as data of PeriodicArray

### DIFF
--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -43,7 +43,7 @@ function FiniteMPOHamiltonian(Ws::AbstractVector{O}) where {O <: MPOTensor}
     return FiniteMPOHamiltonian{O}(Ws)
 end
 
-const InfiniteMPOHamiltonian{O <: MPOTensor} = MPOHamiltonian{O, PeriodicVector{O}}
+const InfiniteMPOHamiltonian{O <: MPOTensor} = MPOHamiltonian{O, <:PeriodicVector{O}}
 Base.isfinite(::Type{<:InfiniteMPOHamiltonian}) = false
 
 function InfiniteMPOHamiltonian(Ws::AbstractVector{O}) where {O <: MPOTensor}

--- a/src/utility/periodicarray.jl
+++ b/src/utility/periodicarray.jl
@@ -94,15 +94,15 @@ end
 Base.BroadcastStyle(::Type{T}) where {T <: PeriodicArray} = Broadcast.ArrayStyle{T}()
 
 function Base.similar(
-        bc::Broadcast.Broadcasted{<:Broadcast.ArrayStyle{<:PeriodicArray}}, ::Type{T}
-    ) where {T}
-    return PeriodicArray(similar(Array{T}, axes(bc)))
+        bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{PeriodicArray{T, N, A}}}, ::Type{ElType}
+    ) where {A <: AbstractArray{T, N}} where {T, N, ElType}
+    return PeriodicArray(similar(convert(Broadcast.Broadcasted{typeof(Broadcast.BroadcastStyle(A))}, bc), ElType))
 end
 
 # Conversion
 # ----------
-Base.convert(::Type{T}, A::AbstractArray) where {T <: PeriodicArray} = T(A)
+Base.convert(::Type{PeriodicArray}, A::AbstractArray) = PeriodicArray(A)
 Base.convert(::Type{T}, A::PeriodicArray) where {T <: AbstractArray} = convert(T, parent(A))
 # fix ambiguities
-Base.convert(::Type{T}, A::PeriodicArray) where {T <: PeriodicArray} = A
-Base.convert(::Type{T}, A::PeriodicArray) where {T <: Array} = parent(A)
+Base.convert(::Type{PeriodicArray}, A::PeriodicArray) = A
+Base.convert(::Type{T}, A::PeriodicArray) where {T <: AbstractArray} = convert(T, parent(A))


### PR DESCRIPTION
In this PR, I change the `PeriodicArray` type, such that it can be used on any `AbstractArray`.
This has the advantage that the user can supply a suitable array for special applications such as MPI parallelization.

One major downside is that now `PeriodicVector{O}` is not concrete anymore. One could circumvent this in the code by replacing all `PeriodicVector{O}` by `PeriodicVector{O,A} where {A<:AbstractVector{O}} where {O}` and types such as `InfiniteMPS` to carry the typeinformation `A<:AbstractVector{O}` as a type parameter.