### PR TITLE
Implement Styles for `AbstractMPS`

### DIFF
--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -256,8 +256,7 @@ TensorKit utility
 ===========================================================================================#
 
 function TensorKit.dot(ψ₁::AbstractMPS, ψ₂::AbstractMPS; kwargs...)
-    geometry_style = GeometryStyle(ψ₁, ψ₂)
-    return TensorKit.dot(geometry_style, ψ₁, ψ₂; kwargs...)
+    return TensorKit.dot(GeometryStyle(ψ₁, ψ₂), ψ₁, ψ₂; kwargs...)
 end
 function Base.isapprox(ψ₁::AbstractMPS, ψ₂::AbstractMPS; kwargs...)
     return isapprox(dot(ψ₁, ψ₂), 1; kwargs...)

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -337,7 +337,7 @@ Base.@propagate_inbounds function Base.getindex(ψ::FiniteMPS, i::Int)
 end
 
 # TODO: check where gauge center is to determine efficient kind
-AC2(psi::FiniteMPS, site::Int) = psi.AC[site] * _transpose_tail(psi.AR[site + 1])
+AC2(::FiniteChainStyle, psi::AbstractMPS, site::Integer) = psi.AC[site] * _transpose_tail(psi.AR[site + 1])
 
 _complex_if_not_missing(x) = ismissing(x) ? x : complex(x)
 function Base.complex(mps::FiniteMPS)
@@ -541,14 +541,14 @@ function TensorKit.rmul!(ψ::FiniteMPS, a::Number)
     return ψ
 end
 
-function TensorKit.dot(ψ₁::FiniteMPS, ψ₂::FiniteMPS)
+function TensorKit.dot(::FiniteChainStyle, ψ₁::AbstractMPS, ψ₂::AbstractMPS)
     #todo : rewrite this without having to gauge
     length(ψ₁) == length(ψ₂) || throw(ArgumentError("MPS with different length"))
     ρr = TransferMatrix(ψ₂.AR[2:end], ψ₁.AR[2:end]) * r_RR(ψ₂)
     return tr(_transpose_front(ψ₁.AC[1])' * _transpose_front(ψ₂.AC[1]) * ρr)
 end
 
-function TensorKit.norm(ψ::FiniteMPS)
+function TensorKit.norm(::FiniteChainStyle, ψ::AbstractMPS)
     c = ψ.center
     if isinteger(c) # center is an AC
         return norm(ψ.AC[Int(c)])
@@ -556,18 +556,17 @@ function TensorKit.norm(ψ::FiniteMPS)
         return norm(ψ.C[Int(c - 1 / 2)])
     end
 end
-TensorKit.normalize!(ψ::FiniteMPS) = rmul!(ψ, 1 / norm(ψ))
-TensorKit.normalize(ψ::FiniteMPS) = normalize!(copy(ψ))
+TensorKit.normalize!(::FiniteChainStyle, ψ::AbstractMPS) = rmul!(ψ, 1 / norm(ψ))
 
 #===========================================================================================
 Fixedpoints
 ===========================================================================================#
 
-function r_RR(ψ::FiniteMPS, site::Int = length(ψ))
+function r_RR(::FiniteChainStyle, ψ::AbstractMPS, site::Int = length(ψ))
     Vr = right_virtualspace(ψ.AR[site])
     return isomorphism(storagetype(site_type(ψ)), Vr ← Vr)
 end
-function l_LL(ψ::FiniteMPS, site::Int = 1)
+function l_LL(::FiniteChainStyle, ψ::AbstractMPS, site::Int = 1)
     Vl = left_virtualspace(ψ.AL[site])
     return isomorphism(storagetype(site_type(ψ)), Vl ← Vl)
 end

--- a/test/states.jl
+++ b/test/states.jl
@@ -11,6 +11,7 @@ module TestStates
     using MPSKit: _transpose_front, _transpose_tail
     using MPSKit: GeometryStyle, FiniteChainStyle, InfiniteChainStyle
     using MPSKit: TransferMatrix
+    using MPSKit: AC2
     using TensorKit
     using TensorKit: ℙ
 
@@ -120,6 +121,9 @@ module TestStates
         @test all(x -> x ≾ D, left_virtualspace(ψ))
         @test all(x -> x ≾ D, right_virtualspace(ψ))
 
+        normalize!(ψ)
+        @test norm(ψ) ≈ norm(InfiniteChainStyle(), ψ) ≈ 1.0
+
         for i in 1:length(ψ)
             @plansor difference[-1 -2; -3] := ψ.AL[i][-1 -2; 1] * ψ.C[i][1; -3] -
                 ψ.C[i - 1][-1; 1] * ψ.AR[i][1 -2; -3]
@@ -134,6 +138,17 @@ module TestStates
             @test TransferMatrix(ψ.AL[i], ψ.AR[i]) * r_LR(ψ, i) ≈ r_LR(ψ, i + 1)
             @test TransferMatrix(ψ.AR[i], ψ.AL[i]) * r_RL(ψ, i) ≈ r_RL(ψ, i + 1)
             @test TransferMatrix(ψ.AR[i], ψ.AR[i]) * r_RR(ψ, i) ≈ r_RR(ψ, i + 1)
+
+            @test l_LL(ψ, i) ≈ l_LL(InfiniteChainStyle(), ψ, i)
+            @test l_LR(ψ, i) ≈ l_LR(InfiniteChainStyle(), ψ, i)
+            @test l_RL(ψ, i) ≈ l_RL(InfiniteChainStyle(), ψ, i)
+            @test l_RR(ψ, i) ≈ l_RR(InfiniteChainStyle(), ψ, i)
+            @test r_LL(ψ, i) ≈ r_LL(InfiniteChainStyle(), ψ, i)
+            @test r_LR(ψ, i) ≈ r_LR(InfiniteChainStyle(), ψ, i)
+            @test r_RL(ψ, i) ≈ r_RL(InfiniteChainStyle(), ψ, i)
+            @test r_RR(ψ, i) ≈ r_RR(InfiniteChainStyle(), ψ, i)
+
+            @test @constinferred AC2(ψ, i) ≈ AC2(InfiniteChainStyle(), ψ, i)
         end
     end
 


### PR DESCRIPTION
This PR implements the methods `AC2`, `dot`, `isapprox`, `norm`, `normalize(!)` as well as the left and right fixedpoints for an `AbstractMPS` by dispatching on `GeometryStyle`. These functions are currently defined for `FiniteMPS` and `InfiniteMPS`. For other types of `AbstractMPS`, there exist more specialized functions, so the dispatch on `GeometryStyle` is skipped making these changes non-breaking.

Examples for the `Style` system are
```julia 
function TensorKit.dot(::FiniteChainStyle, ψ₁::AbstractMPS, ψ₂::AbstractMPS)
    #todo : rewrite this without having to gauge
    length(ψ₁) == length(ψ₂) || throw(ArgumentError("MPS with different length"))
    ρr = TransferMatrix(ψ₂.AR[2:end], ψ₁.AR[2:end]) * r_RR(ψ₂)
    return tr(_transpose_front(ψ₁.AC[1])' * _transpose_front(ψ₂.AC[1]) * ρr)
end
```
for the `FiniteMPS` and 
```julia 
function AC2(::InfiniteChainStyle, ψ::AbstractMPS, i::Integer; kind = :ACAR)
    if kind == :ACAR
        return ψ.AC[i] * _transpose_tail(ψ.AR[i + 1])
    elseif kind == :ALAC
        return ψ.AL[i] * _transpose_tail(ψ.AC[i + 1])
    else
        throw(ArgumentError("Invalid kind: $kind"))
    end
end
```
for the `InfiniteMPS`.