### PR TITLE
[WIP] Implement styles in a top-to-bottom approach

### DIFF
--- a/src/algorithms/derivatives/hamiltonian_derivatives.jl
+++ b/src/algorithms/derivatives/hamiltonian_derivatives.jl
@@ -69,15 +69,8 @@ end
 
 # Constructors
 # ------------
-const _HAM_MPS_TYPES = Union{
-    FiniteMPS{<:MPSTensor},
-    WindowMPS{<:MPSTensor},
-    InfiniteMPS{<:MPSTensor},
-}
-
-function AC_hamiltonian(
-        site::Int, below::_HAM_MPS_TYPES, operator::MPOHamiltonian{<:JordanMPOTensor},
-        above::_HAM_MPS_TYPES, envs
+function AC_hamiltonian(::GeometryStyle, ::HamiltonianStyle,
+        site::Int, below, operator, above, envs
     )
     GL = leftenv(envs, site, below)
     GR = rightenv(envs, site, below)
@@ -147,9 +140,8 @@ function AC_hamiltonian(
     )
 end
 
-function AC2_hamiltonian(
-        site::Int, below::_HAM_MPS_TYPES, operator::MPOHamiltonian{<:JordanMPOTensor},
-        above::_HAM_MPS_TYPES, envs
+function AC2_hamiltonian(::GeometryStyle, ::HamiltonianStyle,
+        site::Int, below, operator, above, envs
     )
     GL = leftenv(envs, site, below)
     GR = rightenv(envs, site + 1, below)

--- a/src/algorithms/derivatives/mpo_derivatives.jl
+++ b/src/algorithms/derivatives/mpo_derivatives.jl
@@ -23,13 +23,27 @@ MPO_AC2_Hamiltonian(GL, O1, O2, GR) = MPODerivativeOperator(GL, (O1, O2), GR)
 # Constructors
 # ------------
 function C_hamiltonian(site::Int, below, operator, above, envs)
+    return C_hamiltonian(GeometryStyle(below, operator, above), OperatorStyle(operator), 
+        site, below, operator, above, envs)
+end
+function C_hamiltonian(::GeometryStyle, ::OperatorStyle, site::Int, below, operator, above, envs)
     return MPO_C_Hamiltonian(leftenv(envs, site + 1, below), rightenv(envs, site, below))
 end
 function AC_hamiltonian(site::Int, below, operator, above, envs)
+    return AC_hamiltonian(
+        GeometryStyle(below, operator, above), OperatorStyle(operator), site, below, operator, above, envs
+    )
+end
+function AC_hamiltonian(::GeometryStyle, ::OperatorStyle, site::Int, below, operator, above, envs)
     O = isnothing(operator) ? nothing : operator[site]
     return MPO_AC_Hamiltonian(leftenv(envs, site, below), O, rightenv(envs, site, below))
 end
 function AC2_hamiltonian(site::Int, below, operator, above, envs)
+    return AC2_hamiltonian(
+        GeometryStyle(below, operator, above), OperatorStyle(operator), site, below, operator, above, envs
+    )
+end
+function AC2_hamiltonian(::GeometryStyle, ::OperatorStyle, site::Int, below, operator, above, envs)
     O1, O2 = isnothing(operator) ? (nothing, nothing) : (operator[site], operator[site + 1])
     return MPO_AC2_Hamiltonian(
         leftenv(envs, site, below), O1, O2, rightenv(envs, site + 1, below)

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -26,7 +26,7 @@ function find_groundstate(
         tol = Defaults.tol, maxiter = Defaults.maxiter,
         verbosity = Defaults.verbosity, trscheme = nothing
     )
-    if isa(ψ, InfiniteMPS)
+    if GeometryStyle(ψ) == InfiniteChainStyle() 
         alg = VUMPS(; tol = max(1.0e-4, tol), verbosity, maxiter)
         if tol < 1.0e-4
             alg = alg & GradientGrassmann(; tol = tol, maxiter, verbosity)
@@ -34,7 +34,7 @@ function find_groundstate(
         if !isnothing(trscheme)
             alg = IDMRG2(; tol = min(1.0e-2, 100tol), verbosity, trscheme) & alg
         end
-    elseif isa(ψ, AbstractFiniteMPS)
+    elseif GeometryStyle(ψ) == FiniteChainStyle()
         alg = DMRG(; tol, maxiter, verbosity)
         if !isnothing(trscheme)
             alg = DMRG2(; tol = min(1.0e-2, 100tol), verbosity, trscheme) & alg

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -26,7 +26,7 @@ function find_groundstate(
         tol = Defaults.tol, maxiter = Defaults.maxiter,
         verbosity = Defaults.verbosity, trscheme = nothing
     )
-    if GeometryStyle(ψ) == InfiniteChainStyle() 
+    if GeometryStyle(ψ) == InfiniteChainStyle()
         alg = VUMPS(; tol = max(1.0e-4, tol), verbosity, maxiter)
         if tol < 1.0e-4
             alg = alg & GradientGrassmann(; tol = tol, maxiter, verbosity)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -72,7 +72,7 @@ end
 
 function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps, operator)) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
     (length(mps) ≤ 1 && alg isa IDMRG2) && throw(ArgumentError("unit cell should be >= 2"))
-    GeometryStyle(operator, mps) == InfiniteChainStyle() && throw(ArgumentError("IDMRG only supports infinite systems."))
+    GeometryStyle(operator, mps) != InfiniteChainStyle() && throw(ArgumentError("IDMRG only supports infinite systems."))
     log = alg isa IDMRG ? IterLog("IDMRG") : IterLog("IDMRG2")
     mps = copy(mps)
     iter = 0

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -72,6 +72,7 @@ end
 
 function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps, operator)) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
     (length(mps) ≤ 1 && alg isa IDMRG2) && throw(ArgumentError("unit cell should be >= 2"))
+    GeometryStyle(operator, mps) == InfiniteChainStyle() && throw(ArgumentError("IDMRG only supports infinite systems."))
     log = alg isa IDMRG ? IterLog("IDMRG") : IterLog("IDMRG2")
     mps = copy(mps)
     iter = 0

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -55,7 +55,7 @@ function dominant_eigsolve(
         operator, mps, alg::VUMPS, envs = environments(mps, operator);
         which
     )
-    GeometryStyle(operator, mps) == InfiniteChainStyle() && throw(ArgumentError("VUMPS only supports infinite systems."))
+    GeometryStyle(operator, mps) != InfiniteChainStyle() && throw(ArgumentError("VUMPS only supports infinite systems."))
     log = IterLog("VUMPS")
     iter = 0
     ϵ = calc_galerkin(mps, operator, mps, envs)

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -46,7 +46,7 @@ struct VUMPSState{S, O, E}
 end
 
 function find_groundstate(
-        mps::InfiniteMPS, operator, alg::VUMPS, envs = environments(mps, operator)
+        mps, operator, alg::VUMPS, envs = environments(mps, operator)
     )
     return dominant_eigsolve(operator, mps, alg, envs; which = :SR)
 end
@@ -55,6 +55,7 @@ function dominant_eigsolve(
         operator, mps, alg::VUMPS, envs = environments(mps, operator);
         which
     )
+    GeometryStyle(operator, mps) == InfiniteChainStyle() && throw(ArgumentError("VUMPS only supports infinite systems."))
     log = IterLog("VUMPS")
     iter = 0
     ϵ = calc_galerkin(mps, operator, mps, envs)

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -30,6 +30,9 @@ Base.complex(x::LazySum) = LazySum(complex.(x.ops))
 TimeDependence(x::LazySum) = istimed(x) ? TimeDependent() : NotTimeDependent()
 istimed(x::LazySum) = any(istimed, x)
 
+OperatorStyle(::Type{LazySum{O}}) where {O} = OperatorStyle(O)
+GeometryStyle(::Type{LazySum{O}}) where {O} = GeometryStyle(O
+
 # constructors
 LazySum(x) = LazySum([x])
 LazySum(ops::AbstractVector, fs::AbstractVector) = LazySum(map(MultipliedOperator, ops, fs))

--- a/src/operators/lazysum.jl
+++ b/src/operators/lazysum.jl
@@ -31,7 +31,7 @@ TimeDependence(x::LazySum) = istimed(x) ? TimeDependent() : NotTimeDependent()
 istimed(x::LazySum) = any(istimed, x)
 
 OperatorStyle(::Type{LazySum{O}}) where {O} = OperatorStyle(O)
-GeometryStyle(::Type{LazySum{O}}) where {O} = GeometryStyle(O
+GeometryStyle(::Type{LazySum{O}}) where {O} = GeometryStyle(O)
 
 # constructors
 LazySum(x) = LazySum([x])


### PR DESCRIPTION
I am currently working on getting the algorithms to run for user-defined `AbstractMPS` types.
To this end, I will go through the algorithms (currently focussing on `IDMRG` and `VUMPS`) and implement the `Style` interface for the highest-level functions, which are called in these algorithms.

Examples for these are `calc_galerkin`, `expectation_value`, `environments`, `recalculate!`, `(A)C(2)_hamiltonian`, `transfer_leftenv!`, `transfer_rightenv!`.