### PR TITLE
Reduce allocation when computing Galerkin error

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -51,7 +51,7 @@ function calc_galerkin(
     )
     AC´ = AC_hamiltonian(pos, below, operator, above, envs) * above.AC[pos]
     normalize!(AC´)
-    out = add!(AC´, below.AL[pos] * below.AL[pos]' * AC´, -1)
+    out = mul!(AC´, below.AL[pos], below.AL[pos]' * AC´, -1, +1)
     return norm(out)
 end
 function calc_galerkin(


### PR DESCRIPTION
As pointed out by @Jutho (apparently [more than once](https://github.com/QuantumKitHub/MPSKit.jl/pull/78#discussion_r1351867285)), there was some inefficient matrix multiplication and allocations in the existing implementation. 