### PR TITLE
More informative errors for finite mps

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -151,7 +151,7 @@ function marek_gap(above::InfiniteMPS; tol_angle = 0.1, kwargs...)
     return marek_gap(spectrum; tol_angle)
 end
 
-function marek_gap(spectrum::Vector{T}; tol_angle = 0.1) where {T <: Number}
+function marek_gap(spectrum::AbstractVector{T}; tol_angle = 0.1) where {T <: Number}
     # Remove 1s from the spectrum
     inds = findall(abs.(spectrum) .< 1 - 1.0e-12)
     length(spectrum) - length(inds) < 2 || @warn "Non-injective mps?"
@@ -187,7 +187,7 @@ function correlation_length(above::InfiniteMPS; kwargs...)
     return 1 / ϵ
 end
 
-function correlation_length(spectrum::Vector{T}; kwargs...) where {T <: Number}
+function correlation_length(spectrum::AbstractVector{T}; kwargs...) where {T <: Number}
     ϵ, = marek_gap(spectrum; kwargs...)
     return 1 / ϵ
 end


### PR DESCRIPTION
Small silly change, but while I was being lazy with variable names and confused my finite MPS with infinite MPS, I realised I could call certain functions and get it to error at weird places. This change fixes that. It seemed good to do since these functions are exported, so the generic method was always available.

Unrelated to this, I was also playing around with Cartesian spaces and `transfer_spectrum` would use the sector `Trivial()` to make a `ComplexSpace`, so now it checks the space type instead of sector type. 

Final thing to add: the eigsolve that happens in `transfer_spectrum` defaults to Arnoldi even though the state is fully real. I didn't change this, because I simply don't know how much support we want for real MPSs.