### PR TITLE
Dispatch `find_groundstate` on `GeometryStyle`

### DIFF
--- a/src/algorithms/groundstate/dmrg.jl
+++ b/src/algorithms/groundstate/dmrg.jl
@@ -32,7 +32,7 @@ function DMRG(;
     return DMRG(tol, maxiter, verbosity, alg_eigsolve′, finalize)
 end
 
-function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG, envs = environments(ψ, H))
+function find_groundstate!(ψ, H, alg::DMRG, envs = environments(ψ, H))
     ϵs = map(pos -> calc_galerkin(pos, ψ, H, ψ, envs), 1:length(ψ))
     ϵ = maximum(ϵs)
     log = IterLog("DMRG")
@@ -109,7 +109,7 @@ function DMRG2(;
     return DMRG2(tol, maxiter, verbosity, alg_eigsolve′, alg_svd, trscheme, finalize)
 end
 
-function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG2, envs = environments(ψ, H))
+function find_groundstate!(ψ, H, alg::DMRG2, envs = environments(ψ, H))
     ϵs = map(pos -> calc_galerkin(pos, ψ, H, ψ, envs), 1:length(ψ))
     ϵ = maximum(ϵs)
     log = IterLog("DMRG2")
@@ -166,6 +166,6 @@ function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG2, envs = environm
     return ψ, envs, ϵ
 end
 
-function find_groundstate(ψ, H, alg::Union{DMRG, DMRG2}, envs...; kwargs...)
+function find_groundstate(::FiniteChainStyle, ψ, H, alg::Union{DMRG, DMRG2}, envs...; kwargs...)
     return find_groundstate!(copy(ψ), H, alg, envs...; kwargs...)
 end

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -44,3 +44,10 @@ function find_groundstate(
     end
     return find_groundstate(ψ, H, alg, envs)
 end
+
+function find_groundstate(
+        ψ::AbstractMPS, H::AbstractMPO, alg::Algorithm, 
+        envs = environments(ψ, H)
+    )
+    return find_groundstate(GeometryStyle(ψ, H), ψ, H, alg, envs)
+end

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -46,7 +46,7 @@ function find_groundstate(
 end
 
 function find_groundstate(
-        ψ::AbstractMPS, H::AbstractMPO, alg::Algorithm, 
+        ψ::AbstractMPS, H::AbstractMPO, alg::Algorithm,
         envs = environments(ψ, H)
     )
     return find_groundstate(GeometryStyle(ψ, H), ψ, H, alg, envs)

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -26,7 +26,7 @@ function find_groundstate(
         tol = Defaults.tol, maxiter = Defaults.maxiter,
         verbosity = Defaults.verbosity, trscheme = nothing
     )
-    if isa(ψ, InfiniteMPS)
+    if GeometryStyle(ψ, H) isa InfiniteChainStyle
         alg = VUMPS(; tol = max(1.0e-4, tol), verbosity, maxiter)
         if tol < 1.0e-4
             alg = alg & GradientGrassmann(; tol = tol, maxiter, verbosity)
@@ -34,7 +34,7 @@ function find_groundstate(
         if !isnothing(trscheme)
             alg = IDMRG2(; tol = min(1.0e-2, 100tol), verbosity, trscheme) & alg
         end
-    elseif isa(ψ, AbstractFiniteMPS)
+    elseif GeometryStyle(ψ, H) isa FiniteChainStyle
         alg = DMRG(; tol, maxiter, verbosity)
         if !isnothing(trscheme)
             alg = DMRG2(; tol = min(1.0e-2, 100tol), verbosity, trscheme) & alg

--- a/src/algorithms/groundstate/find_groundstate.jl
+++ b/src/algorithms/groundstate/find_groundstate.jl
@@ -46,7 +46,7 @@ function find_groundstate(
 end
 
 function find_groundstate(
-        ψ::AbstractMPS, H::AbstractMPO, alg::Algorithm,
+        ψ::AbstractMPS, H, alg::Algorithm,
         envs = environments(ψ, H)
     )
     return find_groundstate(GeometryStyle(ψ, H), ψ, H, alg, envs)

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -56,9 +56,10 @@ struct GradientGrassmann{O <: OptimKit.OptimizationAlgorithm, F} <: Algorithm
 end
 
 function find_groundstate(
-        ψ::S, H, alg::GradientGrassmann, envs::P = environments(ψ, H)
+        style::GeometryStyle, ψ::S, H, alg::GradientGrassmann, 
+        envs::P = environments(ψ, H)
     )::Tuple{S, P, Float64} where {S, P}
-    !isa(ψ, FiniteMPS) || dim(ψ.C[end]) == 1 ||
+    !(style isa FiniteChainStyle) || dim(ψ.C[end]) == 1 ||
         @warn "This is not fully supported - split the mps up in a sum of mps's and optimize separately"
     normalize!(ψ)
 

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -56,7 +56,7 @@ struct GradientGrassmann{O <: OptimKit.OptimizationAlgorithm, F} <: Algorithm
 end
 
 function find_groundstate(
-        style::GeometryStyle, ψ::S, H, alg::GradientGrassmann, 
+        style::GeometryStyle, ψ::S, H, alg::GradientGrassmann,
         envs::P = environments(ψ, H)
     )::Tuple{S, P, Float64} where {S, P}
     !(style isa FiniteChainStyle) || dim(ψ.C[end]) == 1 ||

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -70,7 +70,10 @@ function IDMRGState{T}(mps::S, operator::O, envs::E, iter::Int, ϵ::Float64, ene
     return IDMRGState{S, O, E, T}(mps, operator, envs, iter, ϵ, T(energy))
 end
 
-function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps, operator)) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
+function find_groundstate(
+        ::InfiniteChainStyle, mps, operator, alg::alg_type, 
+        envs = environments(mps, operator)
+    ) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
     (length(mps) ≤ 1 && alg isa IDMRG2) && throw(ArgumentError("unit cell should be >= 2"))
     log = alg isa IDMRG ? IterLog("IDMRG") : IterLog("IDMRG2")
     mps = copy(mps)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -71,7 +71,7 @@ function IDMRGState{T}(mps::S, operator::O, envs::E, iter::Int, ϵ::Float64, ene
 end
 
 function find_groundstate(
-        ::InfiniteChainStyle, mps, operator, alg::alg_type, 
+        ::InfiniteChainStyle, mps, operator, alg::alg_type,
         envs = environments(mps, operator)
     ) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
     (length(mps) ≤ 1 && alg isa IDMRG2) && throw(ArgumentError("unit cell should be >= 2"))

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -46,7 +46,8 @@ struct VUMPSState{S, O, E}
 end
 
 function find_groundstate(
-        mps::InfiniteMPS, operator, alg::VUMPS, envs = environments(mps, operator)
+        ::InfiniteChainStyle, mps, operator, alg::VUMPS, 
+        envs = environments(mps, operator)
     )
     return dominant_eigsolve(operator, mps, alg, envs; which = :SR)
 end

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -46,7 +46,7 @@ struct VUMPSState{S, O, E}
 end
 
 function find_groundstate(
-        ::InfiniteChainStyle, mps, operator, alg::VUMPS, 
+        ::InfiniteChainStyle, mps, operator, alg::VUMPS,
         envs = environments(mps, operator)
     )
     return dominant_eigsolve(operator, mps, alg, envs; which = :SR)


### PR DESCRIPTION
Generalizes ground state algorithms to accept arbitrary `ψ::AbstractMPS, H::AbstractMPO`. If an incompatible state or MPO for the algorithm is supplied, one will get a `MethodError` (currently the generic Julia one, but I could also add more verbose error messages).