### PR TITLE
Generalize `calc_galerkin` to `AbstractMPS`

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -74,7 +74,7 @@ function calc_galerkin(
         below::AbstractMPS, operator, above, envs
     )
     return maximum(
-        pos -> calc_galerkin(pos, below, operator, above, envs), 
+        pos -> calc_galerkin(pos, below, operator, above, envs),
         CartesianIndices(size(above))
     )
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -71,7 +71,7 @@ function calc_galerkin(
     return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
 function calc_galerkin(
-        below::AbstractMPS, operator, above, envs
+        below::Union{AbstractMPS, MultilineMPS}, operator, above, envs
     )
     return maximum(
         pos -> calc_galerkin(pos, below, operator, above, envs),

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -76,7 +76,7 @@ function calc_galerkin(
     return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
 end
 function calc_galerkin(
-        below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,Expand commentComment on line L79Resolved
+        below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,
         envs::MultilineEnvironments
     )
     return maximum(

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -71,7 +71,7 @@ function calc_galerkin(
     return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
 function calc_galerkin(
-        below::Union{AbstractMPS, MultilineMPS}, operator, above, envs
+        below::AbstractMPS, operator, above, envs
     )
     return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
 end

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -73,6 +73,12 @@ end
 function calc_galerkin(
         below::AbstractMPS, operator, above, envs
     )
+    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
+end
+function calc_galerkin(
+        below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,Expand commentComment on line L79Resolved
+        envs::MultilineEnvironments
+    )
     return maximum(
         pos -> calc_galerkin(pos, below, operator, above, envs),
         CartesianIndices(size(above))

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -65,14 +65,8 @@ function calc_galerkin(pos::CartesianIndex{2}, below, operator, above, envs)
     row, col = Tuple(pos)
     return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
-function calc_galerkin(below::AbstractMPS, operator, above, envs)
-    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
-end
-function calc_galerkin(below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS, envs::MultilineEnvironments)
-    return maximum(
-        pos -> calc_galerkin(pos, below, operator, above, envs),
-        CartesianIndices(size(above))
-    )
+function calc_galerkin(below, operator, above, envs)
+    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), eachindex(below))
 end
 
 """

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -55,30 +55,20 @@ Concretely, this is the overlap of the current state with the single-site deriva
 \\epsilon = \\left|VL ⋅ \\left(VL^{\\dagger} ⋅ \\frac{\\partial \\text{above}}{\\partial AC_{\\text{pos}}}\\right)\\right|
 ```
 """
-function calc_galerkin(
-        pos, below::AbstractMPS, operator, above, envs
-    )
+function calc_galerkin(pos::Int, below, operator, above, envs)
     AC´ = AC_projection(pos, below, operator, above, envs)
     normalize!(AC´)
     out = mul!(AC´, below.AL[pos], below.AL[pos]' * AC´, -1, +1)
     return norm(out)
 end
-function calc_galerkin(
-        pos::CartesianIndex{2}, below::MultilineMPS, operator::MultilineMPO,
-        above::MultilineMPS, envs::MultilineEnvironments
-    )
-    row, col = pos.I
+function calc_galerkin(pos::CartesianIndex{2}, below, operator, above, envs)
+    row, col = Tuple(pos)
     return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
-function calc_galerkin(
-        below::AbstractMPS, operator, above, envs
-    )
+function calc_galerkin(below::AbstractMPS, operator, above, envs)
     return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
 end
-function calc_galerkin(
-        below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,
-        envs::MultilineEnvironments
-    )
+function calc_galerkin(below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS, envs::MultilineEnvironments)
     return maximum(
         pos -> calc_galerkin(pos, below, operator, above, envs),
         CartesianIndices(size(above))

--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -56,7 +56,7 @@ Concretely, this is the overlap of the current state with the single-site deriva
 ```
 """
 function calc_galerkin(
-        pos::Int, below::Union{InfiniteMPS, FiniteMPS, WindowMPS}, operator, above, envs
+        pos, below::AbstractMPS, operator, above, envs
     )
     AC´ = AC_projection(pos, below, operator, above, envs)
     normalize!(AC´)
@@ -71,16 +71,10 @@ function calc_galerkin(
     return calc_galerkin(col, below[row + 1], operator[row], above[row], envs[row])
 end
 function calc_galerkin(
-        below::Union{InfiniteMPS, FiniteMPS, WindowMPS}, operator, above, envs
-    )
-    return maximum(pos -> calc_galerkin(pos, below, operator, above, envs), 1:length(above))
-end
-function calc_galerkin(
-        below::MultilineMPS, operator::MultilineMPO, above::MultilineMPS,
-        envs::MultilineEnvironments
+        below::AbstractMPS, operator, above, envs
     )
     return maximum(
-        pos -> calc_galerkin(pos, below, operator, above, envs),
+        pos -> calc_galerkin(pos, below, operator, above, envs), 
         CartesianIndices(size(above))
     )
 end


### PR DESCRIPTION
I unified the call to `calc_galerkin` without supplying a position and then lifted the requirements of `Union{InfiniteMPS, FiniteMPS, WindowMPS}` to `AbstractMPS` by keeping the specialized function call for the `MultilineMPS`.