### PR TITLE
Remove explicit call to `InfiniteMPS` in VUMPS

### DIFF
--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -102,7 +102,7 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
         end
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
-        ψ′ = InfiniteMPS(it.state.mps.AR[1:end]; alg_gauge.tol, alg_gauge.maxiter)
+        ψ′ = typeof(mps)(it.state.mps.AR; alg_gauge.tol, alg_gauge.maxiter)
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)
         return ψ′, envs, it.state.ϵ
     end

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -102,8 +102,10 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
         end
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
+        V = _firstspace(it.state.mps.AR[1])
+        C₀ = isomorphism(storagetype(eltype(it.state.mps.AR)), V, V)
         ψ′ = gaugefix!(
-            it.state.mps, copy(it.state.mps.AR);
+            copy(it.state.mps), copy(it.state.mps.AR), C₀;
             tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
         )
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -102,12 +102,7 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
         end
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
-        V = _firstspace(it.state.mps.AR[1])
-        C₀ = isomorphism(storagetype(eltype(it.state.mps.AR)), V, V)
-        ψ′ = gaugefix!(
-            copy(it.state.mps), copy(it.state.mps.AR), C₀;
-            tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
-        )
+        ψ′ = InfiniteMPS(it.state.mps.AR; alg_gauge.tol, alg_gauge.maxiter)
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)
         return ψ′, envs, it.state.ϵ
     end

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -102,7 +102,10 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
         end
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
-        ψ′ = typeof(mps)(it.state.mps.AR; alg_gauge.tol, alg_gauge.maxiter)
+        ψ′ = gaugefix!(
+            similar(it.state.mps), copy(it.state.mps.AR); 
+            tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
+        )
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)
         return ψ′, envs, it.state.ϵ
     end

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -103,7 +103,7 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
         ψ′ = gaugefix!(
-            similar(it.state.mps), copy(it.state.mps.AR); 
+            similar(it.state.mps), copy(it.state.mps.AR);
             tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
         )
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -103,7 +103,7 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
         ψ′ = gaugefix!(
-            copy(it.state.mps), copy(it.state.mps.AR);
+            it.state.mps, copy(it.state.mps.AR);
             tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
         )
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -103,7 +103,7 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
 
         alg_gauge = updatetol(alg.alg_gauge, it.state.iter, it.state.ϵ)
         ψ′ = gaugefix!(
-            similar(it.state.mps), copy(it.state.mps.AR);
+            copy(it.state.mps), copy(it.state.mps.AR);
             tol = alg_gauge.tol, maxiter = alg_gauge.maxiter
         )
         envs = recalculate!(it.state.envs, ψ′, it.state.operator, ψ′)

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -152,7 +152,7 @@ function _localupdate_vumps_step!(
 end
 
 function gauge_step!(
-        it::IterativeSolver{<:VUMPS,VUMPSState{S}}, state, ACs::AbstractVector
+        it::IterativeSolver{<:VUMPS, VUMPSState{S}}, state, ACs::AbstractVector
     ) where {S}
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
     return S(ACs, state.mps.C[end]; alg_gauge.tol, alg_gauge.maxiter)

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -151,9 +151,11 @@ function _localupdate_vumps_step!(
     return regauge!(AC, C; alg = alg_orth)
 end
 
-function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractVector)
+function gauge_step!(
+        it::IterativeSolver{<:VUMPS,VUMPSState{S}}, state, ACs::AbstractVector
+    ) where {S}
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
-    return InfiniteMPS(ACs, state.mps.C[end]; alg_gauge.tol, alg_gauge.maxiter)
+    return S(ACs, state.mps.C[end]; alg_gauge.tol, alg_gauge.maxiter)
 end
 function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractMatrix)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -57,11 +57,12 @@ function dominant_eigsolve(
     )
     log = IterLog("VUMPS")
     iter = 0
+    mps = copy(mps)
     ϵ = calc_galerkin(mps, operator, mps, envs)
     alg_environments = updatetol(alg.alg_environments, iter, ϵ)
     recalculate!(envs, mps, operator, mps; alg_environments.tol)
 
-    state = VUMPSState(copy(mps), operator, envs, iter, ϵ, which)
+    state = VUMPSState(mps, operator, envs, iter, ϵ, which)
     it = IterativeSolver(alg, state)
 
     return LoggingExtras.withlevel(; alg.verbosity) do

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -111,7 +111,7 @@ function localupdate_step!(
     mps = state.mps
     src_Cs = mps isa Multiline ? eachcol(mps.C) : mps.C
     src_ACs = mps isa Multiline ? eachcol(mps.AC) : mps.AC
-    ACs = similar(mps.AC)
+    ACs = mps.AL
     dst_ACs = mps isa Multiline ? eachcol(ACs) : ACs
 
     tforeach(eachsite(mps), src_ACs, src_Cs; scheduler) do site, AC₀, C₀
@@ -154,10 +154,12 @@ end
 
 function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractVector)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
-    return gaugefix!(
+    mps = gaugefix!(
         state.mps, ACs, state.mps.C[end];
-        alg_gauge.tol, alg_gauge.maxiter
+        alg_gauge.tol, alg_gauge.maxiter, order = :R
     )
+    mul!.(mps.AC, mps.AL, mps.C)
+    return mps
 end
 function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractMatrix)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -61,7 +61,7 @@ function dominant_eigsolve(
     alg_environments = updatetol(alg.alg_environments, iter, ϵ)
     recalculate!(envs, mps, operator, mps; alg_environments.tol)
 
-    state = VUMPSState(mps, operator, envs, iter, ϵ, which)
+    state = VUMPSState(copy(mps), operator, envs, iter, ϵ, which)
     it = IterativeSolver(alg, state)
 
     return LoggingExtras.withlevel(; alg.verbosity) do

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -154,7 +154,7 @@ end
 function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractVector)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
     return gaugefix!(
-        state.mps, ACs, state.mps.C[end]; 
+        state.mps, ACs, state.mps.C[end];
         alg_gauge.tol, alg_gauge.maxiter
     )
 end

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -151,11 +151,12 @@ function _localupdate_vumps_step!(
     return regauge!(AC, C; alg = alg_orth)
 end
 
-function gauge_step!(
-        it::IterativeSolver{<:VUMPS, VUMPSState{S}}, state, ACs::AbstractVector
-    ) where {S}
+function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractVector)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
-    return S(ACs, state.mps.C[end]; alg_gauge.tol, alg_gauge.maxiter)
+    return gaugefix!(
+        state.mps, ACs, state.mps.C[end]; 
+        alg_gauge.tol, alg_gauge.maxiter
+    )
 end
 function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractMatrix)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)


### PR DESCRIPTION
I remove the explicit call to `InfiniteMPS` in `VUMPS` and instead use `gaugefix!` in the `gauge_stetp!`.