### PR TITLE
Fixing changebonds, some inconsistency remaining

### DIFF
--- a/src/algorithms/changebonds/changebonds.jl
+++ b/src/algorithms/changebonds/changebonds.jl
@@ -9,15 +9,18 @@ See also: [`SvdCut`](@ref), [`RandExpand`](@ref), [`VUMPSSvdCut`](@ref), [`Optim
 function changebonds end
 function changebonds! end
 
+
+##= This is never useful
 # write in terms of MultilineMPS
 function changebonds(
-        ψ::InfiniteMPS, operator::InfiniteMPO, alg, envs = environments(ψ, operator)
+        ψ::InfiniteMPS, operator::InfiniteMPO, alg::OptimalExpand, envs = environments(ψ, operator)
     )
     ψ′, envs′ = changebonds(
         convert(MultilineMPS, ψ), convert(MultilineMPO, operator), alg, Multiline([envs])
     )
     return convert(InfiniteMPS, ψ′), envs
 end
+# =#
 
 _expand(ψ, AL′, AR′) = _expand!(copy(ψ), AL′, AR′)
 function _expand!(ψ::InfiniteMPS, AL′::PeriodicVector, AR′::PeriodicVector)

--- a/src/algorithms/changebonds/changebonds.jl
+++ b/src/algorithms/changebonds/changebonds.jl
@@ -3,6 +3,9 @@
     changebonds(ψ::AbstractMPS, alg) -> ψ′
 
 Change the bond dimension of `ψ` using the algorithm `alg`, and return the new `ψ` and the new `envs`.
+For AbstractInfiniteMPS, changebonds returns new environments without modifying the one provided.
+changedbonds! can modifiy both the provided state and environments, depending on the algorithm.
+For FiniteMPS, changebonds also modifies the environments.
 
 See also: [`SvdCut`](@ref), [`RandExpand`](@ref), [`VUMPSSvdCut`](@ref), [`OptimalExpand`](@ref)
 """

--- a/src/algorithms/changebonds/changebonds.jl
+++ b/src/algorithms/changebonds/changebonds.jl
@@ -9,19 +9,6 @@ See also: [`SvdCut`](@ref), [`RandExpand`](@ref), [`VUMPSSvdCut`](@ref), [`Optim
 function changebonds end
 function changebonds! end
 
-
-##= This is never useful
-# write in terms of MultilineMPS
-function changebonds(
-        ψ::InfiniteMPS, operator::InfiniteMPO, alg::OptimalExpand, envs = environments(ψ, operator)
-    )
-    ψ′, envs′ = changebonds(
-        convert(MultilineMPS, ψ), convert(MultilineMPO, operator), alg, Multiline([envs])
-    )
-    return convert(InfiniteMPS, ψ′), envs
-end
-# =#
-
 _expand(ψ, AL′, AR′) = _expand!(copy(ψ), AL′, AR′)
 function _expand!(ψ::InfiniteMPS, AL′::PeriodicVector, AR′::PeriodicVector)
     for i in 1:length(ψ)

--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -24,7 +24,7 @@ function changebonds(
     ψ′, envs′ = changebonds(
         convert(MultilineMPS, ψ), convert(MultilineMPO, operator), alg, Multiline([envs])
     )
-    return convert(InfiniteMPS, ψ′), envs #This does not sound safe, it relies on the onsite modification of the environments, and the compatibility of the conversion
+    return convert(InfiniteMPS, ψ′), only(parent(envs′))
 end
 # =#
 

--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -5,7 +5,8 @@ An algorithm that expands the given mps as described in
 [Zauner-Stauber et al. Phys. Rev. B 97 (2018)](@cite zauner-stauber2018), by selecting the
 dominant contributions of a two-site updated MPS tensor, orthogonal to the original ψ.
 
-changedbonds! is only defined for FiniteMPS, and modify its environment.
+!!! note
+    [`changebonds!`](@ref) is only defined for `FiniteMPS`, and modifies both the state and its environment.
 
 ## Fields
 
@@ -19,8 +20,7 @@ $(TYPEDFIELDS)
     trscheme::TruncationStrategy
 end
 
-##= This is only useful for OptimalExpand
-### Simple wrapper to convert between diffrent type of InifniteMPS.
+# Simple wrapper to convert between diffrent type of InifniteMPS.
 function changebonds(
         ψ::InfiniteMPS, operator::InfiniteMPO, alg::OptimalExpand, envs = environments(ψ, operator)
     )
@@ -29,7 +29,6 @@ function changebonds(
     )
     return convert(InfiniteMPS, ψ′), only(parent(envs′))
 end
-# =#
 
 function changebonds(
         ψ::InfiniteMPS, H::InfiniteMPOHamiltonian, alg::OptimalExpand,

--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -5,6 +5,8 @@ An algorithm that expands the given mps as described in
 [Zauner-Stauber et al. Phys. Rev. B 97 (2018)](@cite zauner-stauber2018), by selecting the
 dominant contributions of a two-site updated MPS tensor, orthogonal to the original ψ.
 
+changedbonds! is only defined for FiniteMPS, and modify its environment.
+
 ## Fields
 
 $(TYPEDFIELDS)
@@ -18,6 +20,7 @@ $(TYPEDFIELDS)
 end
 
 ##= This is only useful for OptimalExpand
+### Simple wrapper to convert between diffrent type of InifniteMPS.
 function changebonds(
         ψ::InfiniteMPS, operator::InfiniteMPO, alg::OptimalExpand, envs = environments(ψ, operator)
     )
@@ -50,7 +53,7 @@ function changebonds(
     end
 
     newψ = _expand(ψ, AL′, AR′)
-    recalculate!(envs, newψ, H)
+    envs = environments(newψ, H)
     return newψ, envs
 end
 
@@ -75,13 +78,14 @@ function changebonds(ψ::MultilineMPS, H, alg::OptimalExpand, envs = environment
     end
 
     newψ = _expand(ψ, AL′, AR′)
-    recalculate!(envs, newψ, H)
+    envs = environments(newψ, H) #  recalculate!(envs, newψ, H)
     return newψ, envs
 end
 
 function changebonds(ψ::AbstractFiniteMPS, H, alg::OptimalExpand, envs = environments(ψ, H))
     return changebonds!(copy(ψ), H, alg, envs)
 end
+
 function changebonds!(ψ::AbstractFiniteMPS, H, alg::OptimalExpand, envs = environments(ψ, H))
     #inspired by the infinite mps algorithm, alternative is to use https://arxiv.org/pdf/1501.05504.pdf
 

--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -17,6 +17,17 @@ $(TYPEDFIELDS)
     trscheme::TruncationStrategy
 end
 
+##= This is only useful for OptimalExpand
+function changebonds(
+        ψ::InfiniteMPS, operator::InfiniteMPO, alg::OptimalExpand, envs = environments(ψ, operator)
+    )
+    ψ′, envs′ = changebonds(
+        convert(MultilineMPS, ψ), convert(MultilineMPO, operator), alg, Multiline([envs])
+    )
+    return convert(InfiniteMPS, ψ′), envs #This does not sound safe, it relies on the onsite modification of the environments, and the compatibility of the conversion
+end
+# =#
+
 function changebonds(
         ψ::InfiniteMPS, H::InfiniteMPOHamiltonian, alg::OptimalExpand,
         envs = environments(ψ, H)

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -9,6 +9,9 @@ parallel, and therefore the expansion will never go beyond the local two-site su
 The truncation strategy dictates the number of expanded states, by generating uniformly
 distributed weights for each state in the two-site space and truncating that.
 
+The environments are not used here.
+changebonds! modify both the provided state and environments.
+
 ## Fields
 
 $(TYPEDFIELDS)
@@ -53,6 +56,13 @@ changebonds(ψ::MultilineMPS, alg::RandExpand) = changebonds!(copy(ψ), alg)
 function changebonds(ψ, H, alg::RandExpand, envs)
     newψ = changebonds(ψ, alg)
     return newψ, environments(newψ, H)
+end
+
+
+function changebonds!(ψ, H, alg::RandExpand, envs)
+    ψ = changebonds!(ψ, alg)
+    recalculate!(envs, ψ, H)
+    return ψ, envs
 end
 
 

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -50,6 +50,12 @@ end
 changebonds(ψ::AbstractMPS, alg::RandExpand) = changebonds!(copy(ψ), alg)
 changebonds(ψ::MultilineMPS, alg::RandExpand) = changebonds!(copy(ψ), alg)
 
+function changebonds(ψ, H, alg::RandExpand, envs)
+  newψ = changebonds(ψ, alg)    
+  return newψ, environments(newψ, H)
+end
+
+
 function changebonds!(ψ::AbstractFiniteMPS, alg::RandExpand)
     for i in 1:(length(ψ) - 1)
         AC2 = randomize!(_transpose_front(ψ.AC[i]) * _transpose_tail(ψ.AR[i + 1]))

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -51,8 +51,8 @@ changebonds(ψ::AbstractMPS, alg::RandExpand) = changebonds!(copy(ψ), alg)
 changebonds(ψ::MultilineMPS, alg::RandExpand) = changebonds!(copy(ψ), alg)
 
 function changebonds(ψ, H, alg::RandExpand, envs)
-  newψ = changebonds(ψ, alg)    
-  return newψ, environments(newψ, H)
+    newψ = changebonds(ψ, alg)
+    return newψ, environments(newψ, H)
 end
 
 

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -9,8 +9,9 @@ parallel, and therefore the expansion will never go beyond the local two-site su
 The truncation strategy dictates the number of expanded states, by generating uniformly
 distributed weights for each state in the two-site space and truncating that.
 
-The environments are not used here.
-changebonds! modify both the provided state and environments.
+!!! note
+    The environments are not used here, but [`changebonds!`](@ref) modifies both the state
+    and environment so they remain consistent.
 
 ## Fields
 

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -108,8 +108,9 @@ function changebonds(ψ::InfiniteMPS, alg::SvdCut)
     return normalize!(ψ)
 end
 
-function changebonds(ψ, H, alg::SvdCut, envs = environments(ψ, H))
-    return changebonds(ψ, alg), envs
+function changebonds(ψ, H, alg::SvdCut, envs)
+  newψ = changebonds(ψ, alg)
+  return newψ, environments(newψ, H)
 end
 
 changebonds(mpo::FiniteMPOHamiltonian, alg::SvdCut) = changebonds!(copy(mpo), alg)

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -109,8 +109,8 @@ function changebonds(ψ::InfiniteMPS, alg::SvdCut)
 end
 
 function changebonds(ψ, H, alg::SvdCut, envs)
-  newψ = changebonds(ψ, alg)
-  return newψ, environments(newψ, H)
+    newψ = changebonds(ψ, alg)
+    return newψ, environments(newψ, H)
 end
 
 changebonds(mpo::FiniteMPOHamiltonian, alg::SvdCut) = changebonds!(copy(mpo), alg)

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -4,6 +4,8 @@ $(TYPEDEF)
 An algorithm that uses truncated SVD to change the bond dimension of a state or operator.
 This is achieved by a sweeping algorithm that locally performs (optimal) truncations in a gauged basis.
 
+changedbonds! is only defined for FiniteMPS and FiniteMPO.
+
 See also [`changebonds(!)`](@ref changebonds)
 
 ## Fields
@@ -34,6 +36,12 @@ function changebonds!(ψ::AbstractFiniteMPS, alg::SvdCut; normalize::Bool = true
         ψ.AC[i + 1] = (S, AR′)
     end
     return normalize ? normalize!(ψ) : ψ
+end
+
+function changebonds!(ψ::AbstractFiniteMPS, H, alg::SvdCut, envs)
+    ψ = changebonds!(ψ, alg)
+    recalculate!(envs, ψ, H)
+    return ψ, envs
 end
 
 # Note: it might be better to go to an MPS representation first

--- a/src/algorithms/changebonds/vumpssvd.jl
+++ b/src/algorithms/changebonds/vumpssvd.jl
@@ -3,6 +3,8 @@ $(TYPEDEF)
 
 An algorithm that uses a two-site update step to change the bond dimension of a state.
 
+changedbonds! is not defined.
+
 ## Fields
 
 $(TYPEDFIELDS)
@@ -44,9 +46,8 @@ function changebonds_1(
     collapsed = InfiniteMPS(
         [nstate.AL[1]], nstate.C[1]; alg.alg_gauge.tol, alg.alg_gauge.maxiter
     )
-    recalculate!(envs, collapsed, H, collapsed)
 
-    return collapsed, envs
+    return collapsed, environments(collapsed, H)
 end
 
 function changebonds_n(state::InfiniteMPS, H, alg::VUMPSSvdCut, envs = environments(state, H))
@@ -75,7 +76,7 @@ function changebonds_n(state::InfiniteMPS, H, alg::VUMPSSvdCut, envs = environme
         copied[loc] = AL1
         copied[loc + 1] = AL2
         state = InfiniteMPS(copied; alg.alg_gauge.tol, alg.alg_gauge.maxiter)
-        recalculate!(envs, state, H, state)
+        envs = environments(state, H)
     end
     return state, envs
 end

--- a/src/algorithms/changebonds/vumpssvd.jl
+++ b/src/algorithms/changebonds/vumpssvd.jl
@@ -3,7 +3,8 @@ $(TYPEDEF)
 
 An algorithm that uses a two-site update step to change the bond dimension of a state.
 
-changedbonds! is not defined.
+!!! note
+    [`changebonds!`](@ref) is not defined.
 
 ## Fields
 

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -275,6 +275,15 @@ function FiniteMPS(
     return FiniteMPS(rand, Defaults.eltype, Pspaces, maxVspaces; kwargs...)
 end
 
+
+function FiniteMPS(
+        elt::Type, Pspaces::Vector{<:Union{S, CompositeSpace{S}}}, maxVspaces::Union{S, Vector{S}};
+        kwargs...
+    ) where {S <: ElementarySpace}
+    return FiniteMPS(rand, elt, Pspaces, maxVspaces; kwargs...)
+end
+
+
 # Also accept single physical space and length
 function FiniteMPS(N::Int, V::VectorSpace, args...; kwargs...)
     return FiniteMPS(fill(V, N), args...; kwargs...)


### PR DESCRIPTION
Following discussion with @lkdvos 

Here is a small fix for some minor bugs I noticed in changebonds: for RandExpand or SvdCut, the returned environments were not updated after the update of the mps. Schematically, we had
newmps, oldenv = changebonds(oldmps, H, alg = ..., oldenv)
which made any groundstate algorithm failed.
Now the environments are updated such that
newmps, newenv = changebonds(oldmps, H, alg = ..., oldenv)
without touching oldmps or oldenv

Before accepting the update: there are some inconsistencies in the behavior of changebonds.
In particular, for OptimalExpand, env are directly modified in place, which makes oldenv not work with the old mps. Is it intended behavior for memory optimization? If so, I can reproduce a similar behavior for others. It should in any case be advertised.

I modified also slightly the converter between InfiniteMPOHamiltonian and InfiniteMPO which was only used by OptimalExpand. There is some unsafe looking environment update in it, though.

The test pass for FiniteMPS, though I did not investigate it as much. In particular, the environment update in OptimalExpand is hidden in the computation of AC2.

Finally, I added a constructor of the type FiniteMPS(Type, Space, Space) as the syntax works for infiniteMPS and not Finite, which was annoying me.

For reproduction: here is a script that fails before the PR, and pass afterwards:

```
## Infinite chain, InfiniteMPOHamiltonian
L = 2
mps = InfiniteMPS(ComplexF64, repeat([ComplexSpace(2)], L), repeat([ComplexSpace(20)], L) )
H = transverse_field_ising(ComplexF64, Trivial, InfiniteChain(L))
env = environments(mps, H)

for alg in [OptimalExpand, RandExpand, SvdCut, VUMPSSvdCut]
  env = environments(mps, H)
  newmps, newenv = changebonds(mps, H, alg(trscheme = truncrank(10)), env)    
  try
    newmps, newenv, = find_groundstate(newmps, H, VUMPS(; maxiter=1, verbosity=1, tol= 1e-6), newenv)
  catch e
    error("Fail in Infinite $alg")
    #println(e)
  end
end

## Infinite chain, InfiniteMPO
L = 2
mps = InfiniteMPS(ComplexF64, repeat([ComplexSpace(2)], L), repeat([ComplexSpace(20)], L) )
H = InfiniteMPO(transverse_field_ising(ComplexF64, Trivial, InfiniteChain(L)))
env = environments(mps, H)

for alg in [OptimalExpand, RandExpand, SvdCut, VUMPSSvdCut]
  env = environments(mps, H)
  newmps, newenv = changebonds(mps, H, alg(trscheme = truncrank(10)), env)    
  try
    newmps, newenv, = find_groundstate(newmps, H, VUMPS(; maxiter=1, verbosity=1, tol= 1e-6), newenv)
  catch e
    error("Fail in Infinite $alg")
    #println(e)
  end
end


##Finite Chain
L = 10
mps = FiniteMPS(ComplexF64, repeat([ComplexSpace(2)], L), repeat([ComplexSpace(20)], L-1) )
H = transverse_field_ising(ComplexF64, Trivial, FiniteChain(L))
env = environments(mps, H)


for alg in [OptimalExpand, RandExpand, SvdCut]
  env = environments(mps, H)
  newmps, newenv = changebonds(mps, H, alg(trscheme = truncrank(10)), env)    
  try
    newmps, newenv, = find_groundstate(newmps, H, DMRG(; maxiter=1, verbosity=1, tol= 1e-6), newenv)
  catch e
    error("Fail in Finite $alg")
    #println(e)
  end
end```

