### PR TITLE
Add WindowMPOHamiltonian enabling propagators and dynamical DMRG on WindowMPS

### DIFF
--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -19,7 +19,7 @@ export QP, LeftGaugedQP, RightGaugedQP
 export AbstractMPO
 export MPO, FiniteMPO, InfiniteMPO
 export JordanMPOTensor
-export MPOHamiltonian, FiniteMPOHamiltonian, InfiniteMPOHamiltonian
+export MPOHamiltonian, FiniteMPOHamiltonian, InfiniteMPOHamiltonian, WindowMPOHamiltonian
 export MultilineMPO
 export UntimedOperator, TimedOperator, MultipliedOperator, LazySum
 
@@ -123,6 +123,7 @@ include("operators/abstractmpo.jl")
 include("operators/mpo.jl")
 include("operators/jordanmpotensor.jl")
 include("operators/mpohamiltonian.jl") # the mpohamiltonian objects
+include("operators/windowhamiltonian.jl")
 include("operators/ortho.jl")
 include("operators/multilinempo.jl")
 include("operators/projection.jl")

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -19,7 +19,7 @@ export QP, LeftGaugedQP, RightGaugedQP
 export AbstractMPO
 export MPO, FiniteMPO, InfiniteMPO
 export JordanMPOTensor, JordanMPOTensorMap
-export MPOHamiltonian, FiniteMPOHamiltonian, InfiniteMPOHamiltonian
+export MPOHamiltonian, FiniteMPOHamiltonian, InfiniteMPOHamiltonian, WindowMPOHamiltonian
 export MultilineMPO
 export UntimedOperator, TimedOperator, MultipliedOperator, LazySum
 
@@ -122,6 +122,7 @@ include("operators/abstractmpo.jl")
 include("operators/mpo.jl")
 include("operators/jordanmpotensor.jl")
 include("operators/mpohamiltonian.jl") # the mpohamiltonian objects
+include("operators/windowhamiltonian.jl")
 include("operators/ortho.jl")
 include("operators/multilinempo.jl")
 include("operators/projection.jl")

--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -129,6 +129,13 @@ function expectation_value(
 end
 
 function expectation_value(
+        ψ::WindowMPS, H::WindowMPOHamiltonian,
+        envs::AbstractMPSEnvironments = environments(ψ, H)
+    )
+    return dot(ψ, H, ψ, envs) / dot(ψ, ψ)
+end
+
+function expectation_value(
         ψ::InfiniteMPS, H::InfiniteMPOHamiltonian,
         envs::AbstractMPSEnvironments = environments(ψ, H, ψ)
     )

--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -129,6 +129,13 @@ function expectation_value(
 end
 
 function expectation_value(
+        ψ::WindowMPS, H::WindowMPOHamiltonian,
+        envs::AbstractMPSEnvironments = environments(ψ, H)
+    )
+    return dot(ψ, H, ψ, envs) / dot(ψ, ψ)
+end
+
+function expectation_value(
         ψ::InfiniteMPS, H::InfiniteMPOHamiltonian,
         envs::AbstractMPSEnvironments = environments(ψ, H)
     )

--- a/src/algorithms/propagator/corvector.jl
+++ b/src/algorithms/propagator/corvector.jl
@@ -35,7 +35,7 @@ end
 """
     propagator(ψ₀::AbstractFiniteMPS, z::Number, H::MPOHamiltonian, alg::DynamicalDMRG; init=copy(ψ₀))
 
-Calculate the propagator ``\\frac{1}{E₀ + z - H}|ψ₀⟩`` using the dynamical DMRG
+Calculate the propagator ``\\frac{1}{z - H}|ψ₀⟩`` using the dynamical DMRG
 algorithm.
 """
 function propagator end
@@ -47,12 +47,10 @@ An alternative approach to the dynamical DMRG algorithm, without quadratic terms
 less controlled approximation.
 This algorithm minimizes the following cost function
 ```math
-⟨ψ|(H - E)|ψ⟩ - ⟨ψ|ψ₀⟩ - ⟨ψ₀|ψ⟩
+⟨ψ|(z - H)|ψ⟩ - ⟨ψ|ψ₀⟩ - ⟨ψ₀|ψ⟩
 ```
-which is equivalent to the original approach if
-```math
-|ψ₀⟩ = (H - E)|ψ⟩
-```
+
+Returns the approximation of <ψ₀| (z-H)^-1 |ψ₀> and |ψ⟩.
 
 See also [`Jeckelmann`](@ref) for the original approach.
 """
@@ -105,10 +103,19 @@ end
 """
 $(TYPEDEF)
 
-The original flavour of dynamical DMRG, which minimizes the following (quadratic) cost function:
+The original flavour of dynamical DMRG, which minimizes functional (14) from Jeckelmann2002.
 ```math
-|| (H - E) |ψ₀⟩ - |ψ⟩ ||
+|| <ψ| (Re(z) - H)^2 + Im(z)^2 |ψ⟩ +Im(z) (<ψ₀|ψ⟩+<ψ|ψ₀⟩ ||
 ```
+
+This would achieve a minima at
+```math
+-Im(z) |ψ₀⟩ = ((Re(z) - H)^2 + Im(z)^2)|ψ⟩
+```
+
+Together with equation (11) from that same paper we can determine the full propagator (z-H)^-1 |ψ₀>.
+
+Returns the approximation of <ψ₀| (z-H)^-1 |ψ₀> and |ψ⟩.
 
 See also [`NaiveInvert`](@ref) for a less costly but less accurate alternative.
 

--- a/src/algorithms/propagator/corvector.jl
+++ b/src/algorithms/propagator/corvector.jl
@@ -59,7 +59,7 @@ See also [`Jeckelmann`](@ref) for the original approach.
 struct NaiveInvert <: DDMRG_Flavour end
 
 function propagator(
-        A::AbstractFiniteMPS, z::Number, H::FiniteMPOHamiltonian,
+        A::AbstractFiniteMPS, z::Number, H,
         alg::DynamicalDMRG{NaiveInvert}; init = copy(A)
     )
     h_envs = environments(init, H) # environments for h
@@ -119,7 +119,7 @@ See also [`NaiveInvert`](@ref) for a less costly but less accurate alternative.
 struct Jeckelmann <: DDMRG_Flavour end
 
 function propagator(
-        A::AbstractFiniteMPS, z, H::FiniteMPOHamiltonian,
+        A::AbstractFiniteMPS, z, H,
         alg::DynamicalDMRG{Jeckelmann}; init = copy(A)
     )
     ω = real(z)
@@ -176,7 +176,7 @@ function propagator(
 end
 
 function squaredenvs(
-        state::AbstractFiniteMPS, H::FiniteMPOHamiltonian, envs = environments(state, H)
+        state::AbstractFiniteMPS, H, envs = environments(state, H)
     )
     H² = conj(H) * H
     L = length(state)

--- a/src/algorithms/propagator/corvector.jl
+++ b/src/algorithms/propagator/corvector.jl
@@ -35,8 +35,11 @@ end
 """
     propagator(ψ₀::AbstractFiniteMPS, z::Number, H::MPOHamiltonian, alg::DynamicalDMRG; init=copy(ψ₀))
 
-Calculate the propagator ``\\frac{1}{z - H}|ψ₀⟩`` using the dynamical DMRG
+Calculate the action of the propagator ``\\frac{1}{z - H}|ψ₀⟩`` using the dynamical DMRG
 algorithm.
+
+Returns a tuple `(g, ψ)` where `g` is the approximation of the propagator matrix element
+``⟨ψ₀|\\frac{1}{z - H}|ψ₀⟩`` and `ψ` is the MPS approximation of ``\\frac{1}{z - H}|ψ₀⟩``.
 """
 function propagator end
 
@@ -50,7 +53,7 @@ This algorithm minimizes the following cost function
 ⟨ψ|(z - H)|ψ⟩ - ⟨ψ|ψ₀⟩ - ⟨ψ₀|ψ⟩
 ```
 
-Returns the approximation of <ψ₀| (z-H)^-1 |ψ₀> and |ψ⟩.
+Returns the approximation of ``⟨ψ₀|\\frac{1}{z - H}|ψ₀⟩`` and ``\\frac{1}{z - H}|ψ₀⟩``.
 
 See also [`Jeckelmann`](@ref) for the original approach.
 """
@@ -104,18 +107,19 @@ end
 $(TYPEDEF)
 
 The original flavour of dynamical DMRG, which minimizes functional (14) from Jeckelmann2002.
+Writing ``ω = \\mathrm{Re}(z)`` and ``η = \\mathrm{Im}(z)``, this is
 ```math
-|| <ψ| (Re(z) - H)^2 + Im(z)^2 |ψ⟩ +Im(z) (<ψ₀|ψ⟩+<ψ|ψ₀⟩ ||
+W(ψ) = ⟨ψ|(ω - H)^2 + η^2|ψ⟩ + η(⟨ψ₀|ψ⟩ + ⟨ψ|ψ₀⟩)
+```
+which attains its minimum at
+```math
+((ω - H)^2 + η^2)|ψ⟩ = -η|ψ₀⟩
 ```
 
-This would achieve a minima at
-```math
--Im(z) |ψ₀⟩ = ((Re(z) - H)^2 + Im(z)^2)|ψ⟩
-```
+Together with equation (11) from that same paper we can determine the full propagator
+``\\frac{1}{z - H}|ψ₀⟩``.
 
-Together with equation (11) from that same paper we can determine the full propagator (z-H)^-1 |ψ₀>.
-
-Returns the approximation of <ψ₀| (z-H)^-1 |ψ₀> and |ψ⟩.
+Returns the approximation of ``⟨ψ₀|\\frac{1}{z - H}|ψ₀⟩`` and ``\\frac{1}{z - H}|ψ₀⟩``.
 
 See also [`NaiveInvert`](@ref) for a less costly but less accurate alternative.
 

--- a/src/algorithms/propagator/corvector.jl
+++ b/src/algorithms/propagator/corvector.jl
@@ -59,7 +59,7 @@ See also [`Jeckelmann`](@ref) for the original approach.
 struct NaiveInvert <: DDMRG_Flavour end
 
 function propagator(
-        A::AbstractFiniteMPS, z::Number, H::FiniteMPOHamiltonian,
+        A::AbstractFiniteMPS, z::Number, H,
         alg::DynamicalDMRG{NaiveInvert}; init = copy(A)
     )
     h_envs = environments(init, H, init) # environments for h
@@ -119,7 +119,7 @@ See also [`NaiveInvert`](@ref) for a less costly but less accurate alternative.
 struct Jeckelmann <: DDMRG_Flavour end
 
 function propagator(
-        A::AbstractFiniteMPS, z, H::FiniteMPOHamiltonian,
+        A::AbstractFiniteMPS, z, H,
         alg::DynamicalDMRG{Jeckelmann}; init = copy(A)
     )
     ω = real(z)
@@ -176,7 +176,7 @@ function propagator(
 end
 
 function squaredenvs(
-        state::AbstractFiniteMPS, H::FiniteMPOHamiltonian, envs = environments(state, H, state)
+        state::AbstractFiniteMPS, H, envs = environments(state, H, state)
     )
     H² = conj(H) * H
     L = length(state)

--- a/src/algorithms/propagator/corvector.jl
+++ b/src/algorithms/propagator/corvector.jl
@@ -119,7 +119,7 @@ See also [`NaiveInvert`](@ref) for a less costly but less accurate alternative.
 struct Jeckelmann <: DDMRG_Flavour end
 
 function propagator(
-        A::AbstractFiniteMPS, z, H,
+        A::AbstractFiniteMPS, z::Number, H,
         alg::DynamicalDMRG{Jeckelmann}; init = copy(A)
     )
     ω = real(z)

--- a/src/environments/finite_envs.jl
+++ b/src/environments/finite_envs.jl
@@ -59,12 +59,11 @@ end
 function environments(
         below::WindowMPS, O::WindowMPOHamiltonian, above = nothing;
         lenvs = environments(below.left_gs, O.left_ham, below.left_gs),
-        renvs = environments(below.right_gs, O.right_ham, below.right_gs)
+        renvs = environments(below.right_gs, O.right_ham, below.right_gs),
+        leftstart = copy(lenvs.GLs[1]),
+        rightstart = copy(renvs.GRs[end])
     )
-    leftstart = copy(lenvs.GLs[1])
-    rightstart = copy(renvs.GRs[end])
-
-    return environments(below, O.finite_ham, above; leftstart, rightstart)
+    return initialize_environments(below, O.finite_ham, above, leftstart, rightstart)
 end
 
 environments(below::S, above::S) where {S <: Union{FiniteMPS, WindowMPS}} =

--- a/src/environments/finite_envs.jl
+++ b/src/environments/finite_envs.jl
@@ -58,10 +58,12 @@ function environments(
 end
 function environments(
         below::WindowMPS, O::WindowMPOHamiltonian, above = nothing;
-        lenvs = environments(below.left_gs, O.left_ham, below.left_gs),
-        renvs = environments(below.right_gs, O.right_ham, below.right_gs),
-        leftstart = copy(lenvs.GLs[1]),
-        rightstart = copy(renvs.GRs[end])
+        # NOTE: the defaults are deliberately inlined rather than shared via `lenvs`/`renvs`
+        # kwargs: when explicit boundaries are passed (e.g. the squared environments in
+        # `squaredenvs`), we must not trigger the infinite fixed-point solve, which need not
+        # converge for e.g. `conj(H) * H`.
+        leftstart = copy(environments(below.left_gs, O.left_ham, below.left_gs).GLs[1]),
+        rightstart = copy(environments(below.right_gs, O.right_ham, below.right_gs).GRs[end])
     )
     return initialize_environments(below, O.finite_ham, above, leftstart, rightstart)
 end

--- a/src/environments/finite_envs.jl
+++ b/src/environments/finite_envs.jl
@@ -53,14 +53,14 @@ function environments(
     return environments(below, O, above, leftstart, rightstart)
 end
 function environments(
-        below::WindowMPS, O::Union{InfiniteMPOHamiltonian, InfiniteMPO}, above = nothing;
-        lenvs = environments(below.left_gs, O),
-        renvs = environments(below.right_gs, O)
+        below::WindowMPS, O::WindowMPOHamiltonian, above = nothing;
+        lenvs = environments(below.left_gs, O.left_ham),
+        renvs = environments(below.right_gs, O.right_ham)
     )
     leftstart = copy(lenvs.GLs[1])
     rightstart = copy(renvs.GRs[end])
 
-    return environments(below, O, above, leftstart, rightstart)
+    return environments(below, O.finite_ham, above, leftstart, rightstart)
 end
 
 function environments(below::S, above::S) where {S <: Union{FiniteMPS, WindowMPS}}

--- a/src/environments/finite_envs.jl
+++ b/src/environments/finite_envs.jl
@@ -56,6 +56,16 @@ function environments(
     )
     return initialize_environments(below, operator, above, leftstart, rightstart)
 end
+function environments(
+        below::WindowMPS, O::WindowMPOHamiltonian, above = nothing;
+        lenvs = environments(below.left_gs, O.left_ham, below.left_gs),
+        renvs = environments(below.right_gs, O.right_ham, below.right_gs)
+    )
+    leftstart = copy(lenvs.GLs[1])
+    rightstart = copy(renvs.GRs[end])
+
+    return environments(below, O.finite_ham, above; leftstart, rightstart)
+end
 
 environments(below::S, above::S) where {S <: Union{FiniteMPS, WindowMPS}} =
     environments(below, nothing, above)

--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -706,7 +706,7 @@ end
 function Base.similar(H::MPOHamiltonian, ::Type{T}) where {T <: Number}
     return MPOHamiltonian(similar.(parent(H), T))
 end
-
+Base.circshift(H::InfiniteMPOHamiltonian, shift::Integer) = InfiniteMPOHamiltonian(circshift(parent(copy(H)), shift))
 # Linear Algebra
 # --------------
 function Base.:+(

--- a/src/operators/mpohamiltonian.jl
+++ b/src/operators/mpohamiltonian.jl
@@ -707,7 +707,7 @@ end
 function Base.similar(H::MPOHamiltonian, ::Type{TorA}) where {TorA <: Union{Number, DenseVector}}
     return MPOHamiltonian(similar.(parent(H), TorA))
 end
-
+Base.circshift(H::InfiniteMPOHamiltonian, shift::Integer) = InfiniteMPOHamiltonian(circshift(parent(copy(H)), shift))
 # Linear Algebra
 # --------------
 function Base.:+(

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -1,19 +1,38 @@
-"""
-A WindowMPS is a finite MPS embedded between an infinite mps to the left, and an inifite mps to the right. 
-The associated hamiltonian has also an infinite part to the left, a finite hamiltonian in the middle, and an infinite part to the right.
-
-Acts simalar as just a finite hamiltonian, but we 'remember' the boundary hamiltonians.
-"""
-
 # todo - what is the required interface for abstractmpo?
 # support densempo windows?
+"""
+$(TYPEDEF)
+
+The Hamiltonian counterpart of a [`WindowMPS`](@ref): a finite region embedded between an
+infinite environment to the left and to the right.
+It consists of an infinite Hamiltonian to the left, a finite Hamiltonian in the middle, and
+an infinite Hamiltonian to the right.
+
+Acts similar to just a finite Hamiltonian, but we "remember" the boundary Hamiltonians.
+
+## Fields
+
+$(TYPEDFIELDS)
+
+## Constructors
+
+    WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
+
+Construct a `WindowMPOHamiltonian` by carving a finite `interval` out of an infinite
+Hamiltonian `ham`.
+The finite window consists of the sites in `interval`, while the left and right environments
+are copies of `ham` whose unit cells are circshifted so that they line up with the window
+boundaries.
+"""
 struct WindowMPOHamiltonian{O} <: AbstractMPO{O}
+    "Hamiltonian acting on the infinite environment to the left of the window"
     left_ham::InfiniteMPOHamiltonian{O}
+    "Hamiltonian acting on the finite window"
     finite_ham::FiniteMPOHamiltonian{O}
+    "Hamiltonian acting on the infinite environment to the right of the window"
     right_ham::InfiniteMPOHamiltonian{O}
 end
 
-#utility constructor
 function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
 
     # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
@@ -30,8 +49,56 @@ Base.parent(h::WindowMPOHamiltonian) = h.finite_ham
 Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy(h.finite_ham), copy(h.right_ham))
 
 # some basic linalg
-for fun in (:(Base.:+), :(Base.:-), :(Base.:*))
-    @eval $fun(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian) = WindowMPOHamiltonian($fun(a.left_ham, b.left_ham), $fun(a.finite_ham, b.finite_ham), $fun(a.right_ham, b.right_ham))
+# NOTE: `+` cannot be delegated to the regular `FiniteMPOHamiltonian` addition: the finite
+# window carries the full (non-trivial) Jordan virtual spaces at its boundaries, so the two
+# summands have to be block-diagonalized at every site -- including the edges -- exactly like
+# for an `InfiniteMPOHamiltonian`. `-` reuses `+` through the `AbstractMPO` fallback
+# (`a - b == a + (-b)`), and scaling is space-preserving so it works out of the box.
+function Base.:+(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian)
+    return WindowMPOHamiltonian(
+        a.left_ham + b.left_ham,
+        _add_finite_window(a.finite_ham, b.finite_ham),
+        a.right_ham + b.right_ham
+    )
+end
+function Base.:*(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian)
+    return WindowMPOHamiltonian(
+        a.left_ham * b.left_ham, a.finite_ham * b.finite_ham, a.right_ham * b.right_ham
+    )
+end
+
+# Scaling a Jordan Hamiltonian scales every path exactly once; since each path starts in
+# exactly one of the three parts, scaling each part by `α` scales the whole operator by `α`.
+# This also powers unary `-`, `*` and `/` through the `AbstractMPO` fallbacks.
+function VectorInterface.scale(H::WindowMPOHamiltonian, α::Number)
+    return WindowMPOHamiltonian(
+        scale(H.left_ham, α), scale(H.finite_ham, α), scale(H.right_ham, α)
+    )
+end
+
+# Block-diagonal addition of two finite Jordan Hamiltonians that have non-trivial virtual
+# spaces on their boundaries (as produced by slicing an infinite Hamiltonian into a window).
+# Contrary to `Base.:+(::FiniteMPOHamiltonian, ::FiniteMPOHamiltonian)` the boundary spaces
+# are grown as well, mirroring the `InfiniteMPOHamiltonian` implementation.
+function _add_finite_window(
+        H₁::FiniteMPOHamiltonian{O}, H₂::FiniteMPOHamiltonian{O}
+    ) where {O <: JordanMPOTensor}
+    N = check_length(H₁, H₂)
+    H = similar(parent(H₁))
+    Vtriv = leftunitspace(first(physicalspace(H₁)))
+    for i in 1:N
+        A = cat(H₁[i].A, H₂[i].A; dims = (1, 4))
+        B = cat(H₁[i].B, H₂[i].B; dims = 1)
+        C = cat(H₁[i].C, H₂[i].C; dims = 3)
+        D = H₁[i].D + H₂[i].D
+
+        Vleft = ⊞(Vtriv, left_virtualspace(A), Vtriv)
+        Vright = ⊞(Vtriv, right_virtualspace(A), Vtriv)
+        V = Vleft ⊗ physicalspace(A) ← physicalspace(A) ⊗ Vright
+
+        H[i] = JordanMPOTensor(V, A, B, C, D)
+    end
+    return FiniteMPOHamiltonian(H)
 end
 
 TensorKit.dot(

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -1,0 +1,36 @@
+"""
+A WindowMPS is a finite MPS embedded between an infinite mps to the left, and an inifite mps to the right. 
+The associated hamiltonian has also an infinite part to the left, a finite hamiltonian in the middle, and an infinite part to the right.
+
+Acts simalar as just a finite hamiltonian, but we 'remember' the boundary hamiltonians.
+"""
+
+# todo - what is the required interface for abstractmpo?
+# support densempo windows?
+struct WindowMPOHamiltonian{O} <: AbstractMPO{O}
+    left_ham :: InfiniteMPOHamiltonian{O}
+    finite_ham :: FiniteMPOHamiltonian{O}
+    right_ham :: InfiniteMPOHamiltonian{O}
+end
+
+#utility constructor
+function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
+    
+    # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
+    left_edge = (interval.start-1) % length(ham)
+    left_ham = InfiniteMPOHamiltonian([ham[i] for i in (left_edge-length(ham)+1):left_edge])
+    right_edge = (interval.stop+1)%length(ham)
+    right_ham = InfiniteMPOHamiltonian([ham[i] for i in right_edge:(right_edge+length(ham)-1)])
+
+    finite_ham = FiniteMPOHamiltonian([ham[i] for i in  interval])
+    WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
+end
+#
+Base.parent(h::WindowMPOHamiltonian) = h.finite_ham
+
+Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy(h.finite_ham), copy(h.right_ham))
+
+# some basic linalg
+for fun in (:(Base.:+), :(Base.:-), :(Base.:*))
+    @eval $fun(a::WindowMPOHamiltonian,b::WindowMPOHamiltonian) = WindowMPOHamiltonian($fun(a.left_ham,b.left_ham),$fun(a.finite_ham,b.finite_ham),$fun(a.right_ham,b.right_ham))
+end

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -34,13 +34,10 @@ struct WindowMPOHamiltonian{O} <: AbstractMPO{O}
 end
 
 function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
-
-    # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
     left_edge = (interval.start - 1) % length(ham)
     left_ham = circshift(ham, -left_edge)
     right_edge = (interval.stop + 1) % length(ham)
     right_ham = circshift(ham, -right_edge + 1)
-
     finite_ham = FiniteMPOHamiltonian([ham[i] for i in interval])
     return WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
 end
@@ -48,17 +45,28 @@ end
 Base.parent(h::WindowMPOHamiltonian) = h.finite_ham
 Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy(h.finite_ham), copy(h.right_ham))
 
-# some basic linalg
-# NOTE: `+` cannot be delegated to the regular `FiniteMPOHamiltonian` addition: the finite
-# window carries the full (non-trivial) Jordan virtual spaces at its boundaries, so the two
-# summands have to be block-diagonalized at every site -- including the edges -- exactly like
-# for an `InfiniteMPOHamiltonian`. `-` reuses `+` through the `AbstractMPO` fallback
-# (`a - b == a + (-b)`), and scaling is space-preserving so it works out of the box.
 function Base.:+(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian)
+    # the finite window carries full Jordan virtual spaces at its boundaries, so it has to be
+    # block-diagonalized at every site (like an InfiniteMPOHamiltonian) rather than through
+    # the regular FiniteMPOHamiltonian addition
+    Ha, Hb = a.finite_ham, b.finite_ham
+    N = check_length(Ha, Hb)
+    finite_ham = similar(parent(Ha))
+    Vtriv = leftunitspace(first(physicalspace(Ha)))
+    for i in 1:N
+        A = cat(Ha[i].A, Hb[i].A; dims = (1, 4))
+        B = cat(Ha[i].B, Hb[i].B; dims = 1)
+        C = cat(Ha[i].C, Hb[i].C; dims = 3)
+        D = Ha[i].D + Hb[i].D
+
+        Vleft = ⊞(Vtriv, left_virtualspace(A), Vtriv)
+        Vright = ⊞(Vtriv, right_virtualspace(A), Vtriv)
+        V = Vleft ⊗ physicalspace(A) ← physicalspace(A) ⊗ Vright
+
+        finite_ham[i] = JordanMPOTensor(V, A, B, C, D)
+    end
     return WindowMPOHamiltonian(
-        a.left_ham + b.left_ham,
-        _add_finite_window(a.finite_ham, b.finite_ham),
-        a.right_ham + b.right_ham
+        a.left_ham + b.left_ham, FiniteMPOHamiltonian(finite_ham), a.right_ham + b.right_ham
     )
 end
 function Base.:*(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian)
@@ -66,39 +74,10 @@ function Base.:*(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian)
         a.left_ham * b.left_ham, a.finite_ham * b.finite_ham, a.right_ham * b.right_ham
     )
 end
-
-# Scaling a Jordan Hamiltonian scales every path exactly once; since each path starts in
-# exactly one of the three parts, scaling each part by `α` scales the whole operator by `α`.
-# This also powers unary `-`, `*` and `/` through the `AbstractMPO` fallbacks.
 function VectorInterface.scale(H::WindowMPOHamiltonian, α::Number)
     return WindowMPOHamiltonian(
         scale(H.left_ham, α), scale(H.finite_ham, α), scale(H.right_ham, α)
     )
-end
-
-# Block-diagonal addition of two finite Jordan Hamiltonians that have non-trivial virtual
-# spaces on their boundaries (as produced by slicing an infinite Hamiltonian into a window).
-# Contrary to `Base.:+(::FiniteMPOHamiltonian, ::FiniteMPOHamiltonian)` the boundary spaces
-# are grown as well, mirroring the `InfiniteMPOHamiltonian` implementation.
-function _add_finite_window(
-        H₁::FiniteMPOHamiltonian{O}, H₂::FiniteMPOHamiltonian{O}
-    ) where {O <: JordanMPOTensor}
-    N = check_length(H₁, H₂)
-    H = similar(parent(H₁))
-    Vtriv = leftunitspace(first(physicalspace(H₁)))
-    for i in 1:N
-        A = cat(H₁[i].A, H₂[i].A; dims = (1, 4))
-        B = cat(H₁[i].B, H₂[i].B; dims = 1)
-        C = cat(H₁[i].C, H₂[i].C; dims = 3)
-        D = H₁[i].D + H₂[i].D
-
-        Vleft = ⊞(Vtriv, left_virtualspace(A), Vtriv)
-        Vright = ⊞(Vtriv, right_virtualspace(A), Vtriv)
-        V = Vleft ⊗ physicalspace(A) ← physicalspace(A) ⊗ Vright
-
-        H[i] = JordanMPOTensor(V, A, B, C, D)
-    end
-    return FiniteMPOHamiltonian(H)
 end
 
 TensorKit.dot(

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -34,3 +34,8 @@ Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy
 for fun in (:(Base.:+), :(Base.:-), :(Base.:*))
     @eval $fun(a::WindowMPOHamiltonian,b::WindowMPOHamiltonian) = WindowMPOHamiltonian($fun(a.left_ham,b.left_ham),$fun(a.finite_ham,b.finite_ham),$fun(a.right_ham,b.right_ham))
 end
+
+TensorKit.dot(
+        bra::WindowMPS, H::WindowMPOHamiltonian, ket::WindowMPS = bra,
+        envs = environments(bra, H, ket)
+        ) = dot(bra.window, H.finite_ham, ket.window,envs)

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -8,22 +8,22 @@ Acts simalar as just a finite hamiltonian, but we 'remember' the boundary hamilt
 # todo - what is the required interface for abstractmpo?
 # support densempo windows?
 struct WindowMPOHamiltonian{O} <: AbstractMPO{O}
-    left_ham :: InfiniteMPOHamiltonian{O}
-    finite_ham :: FiniteMPOHamiltonian{O}
-    right_ham :: InfiniteMPOHamiltonian{O}
+    left_ham::InfiniteMPOHamiltonian{O}
+    finite_ham::FiniteMPOHamiltonian{O}
+    right_ham::InfiniteMPOHamiltonian{O}
 end
 
 #utility constructor
 function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
-    
-    # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
-    left_edge = (interval.start-1) % length(ham)
-    left_ham = InfiniteMPOHamiltonian([ham[i] for i in (left_edge-length(ham)+1):left_edge])
-    right_edge = (interval.stop+1)%length(ham)
-    right_ham = InfiniteMPOHamiltonian([ham[i] for i in right_edge:(right_edge+length(ham)-1)])
 
-    finite_ham = FiniteMPOHamiltonian([ham[i] for i in  interval])
-    WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
+    # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
+    left_edge = (interval.start - 1) % length(ham)
+    left_ham = InfiniteMPOHamiltonian([ham[i] for i in (left_edge - length(ham) + 1):left_edge])
+    right_edge = (interval.stop + 1) % length(ham)
+    right_ham = InfiniteMPOHamiltonian([ham[i] for i in right_edge:(right_edge + length(ham) - 1)])
+
+    finite_ham = FiniteMPOHamiltonian([ham[i] for i in interval])
+    return WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
 end
 
 
@@ -31,10 +31,10 @@ Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy
 
 # some basic linalg
 for fun in (:(Base.:+), :(Base.:-), :(Base.:*))
-    @eval $fun(a::WindowMPOHamiltonian,b::WindowMPOHamiltonian) = WindowMPOHamiltonian($fun(a.left_ham,b.left_ham),$fun(a.finite_ham,b.finite_ham),$fun(a.right_ham,b.right_ham))
+    @eval $fun(a::WindowMPOHamiltonian, b::WindowMPOHamiltonian) = WindowMPOHamiltonian($fun(a.left_ham, b.left_ham), $fun(a.finite_ham, b.finite_ham), $fun(a.right_ham, b.right_ham))
 end
 
 TensorKit.dot(
-        bra::WindowMPS, H::WindowMPOHamiltonian, ket::WindowMPS = bra,
-        envs = environments(bra, H, ket)
-        ) = dot(bra.window, H.finite_ham, ket.window,envs)
+    bra::WindowMPS, H::WindowMPOHamiltonian, ket::WindowMPS = bra,
+    envs = environments(bra, H, ket)
+) = dot(bra.window, H.finite_ham, ket.window, envs)

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -25,8 +25,7 @@ function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
     finite_ham = FiniteMPOHamiltonian([ham[i] for i in  interval])
     WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
 end
-#
-Base.parent(h::WindowMPOHamiltonian) = h.finite_ham
+
 
 Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy(h.finite_ham), copy(h.right_ham))
 

--- a/src/operators/windowhamiltonian.jl
+++ b/src/operators/windowhamiltonian.jl
@@ -18,15 +18,15 @@ function WindowMPOHamiltonian(ham::InfiniteMPOHamiltonian, interval::UnitRange)
 
     # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
     left_edge = (interval.start - 1) % length(ham)
-    left_ham = InfiniteMPOHamiltonian([ham[i] for i in (left_edge - length(ham) + 1):left_edge])
+    left_ham = circshift(ham, -left_edge)
     right_edge = (interval.stop + 1) % length(ham)
-    right_ham = InfiniteMPOHamiltonian([ham[i] for i in right_edge:(right_edge + length(ham) - 1)])
+    right_ham = circshift(ham, -right_edge + 1)
 
     finite_ham = FiniteMPOHamiltonian([ham[i] for i in interval])
     return WindowMPOHamiltonian(left_ham, finite_ham, right_ham)
 end
 
-
+Base.parent(h::WindowMPOHamiltonian) = h.finite_ham
 Base.copy(h::WindowMPOHamiltonian) = WindowMPOHamiltonian(copy(h.left_ham), copy(h.finite_ham), copy(h.right_ham))
 
 # some basic linalg

--- a/src/states/windowmps.jl
+++ b/src/states/windowmps.jl
@@ -106,18 +106,27 @@ function WindowMPS(N::Int, V::VectorSpace, args...; kwargs...)
     return WindowMPS(fill(V, N), args...; kwargs...)
 end
 
-function WindowMPS(ψ::InfiniteMPS{A, B}, L::Int) where {A, B}
+
+WindowMPS(ψ::InfiniteMPS, L::Int) = WindowMPS(ψ, 1:L)
+
+function WindowMPS(ψ::InfiniteMPS{A, B}, interval::UnitRange) where {A,B}
+
+    # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
+    left_edge = (interval.start - 1) % length(ψ)
+    right_edge = (interval.stop + 1) % length(ψ)
+
+    L = length(interval)
     CLs = Vector{Union{Missing, B}}(missing, L + 1)
     ALs = Vector{Union{Missing, A}}(missing, L)
     ARs = Vector{Union{Missing, A}}(missing, L)
     ACs = Vector{Union{Missing, A}}(missing, L)
 
-    ALs .= ψ.AL[1:L]
-    ARs .= ψ.AR[1:L]
-    ACs .= ψ.AC[1:L]
-    CLs .= ψ.C[0:L]
+    ALs .= ψ.AL[interval]
+    ARs .= ψ.AR[interval]
+    ACs .= ψ.AC[interval]
+    CLs .= ψ.C[interval.start-1:interval.stop]
 
-    return WindowMPS(ψ, FiniteMPS(ALs, ARs, ACs, CLs), ψ)
+    return WindowMPS(circshift(ψ, -left_edge), FiniteMPS(ALs, ARs, ACs, CLs), circshift(ψ,-right_edge + 1))
 end
 
 #===========================================================================================

--- a/src/states/windowmps.jl
+++ b/src/states/windowmps.jl
@@ -109,7 +109,7 @@ end
 
 WindowMPS(ψ::InfiniteMPS, L::Int) = WindowMPS(ψ, 1:L)
 
-function WindowMPS(ψ::InfiniteMPS{A, B}, interval::UnitRange) where {A,B}
+function WindowMPS(ψ::InfiniteMPS{A, B}, interval::UnitRange) where {A, B}
 
     # to make sure the interval corresponds with finite_ham, it is important that the unitcell of the left/right hamiltonians is circshifted correctly
     left_edge = (interval.start - 1) % length(ψ)
@@ -124,9 +124,9 @@ function WindowMPS(ψ::InfiniteMPS{A, B}, interval::UnitRange) where {A,B}
     ALs .= ψ.AL[interval]
     ARs .= ψ.AR[interval]
     ACs .= ψ.AC[interval]
-    CLs .= ψ.C[interval.start-1:interval.stop]
+    CLs .= ψ.C[(interval.start - 1):interval.stop]
 
-    return WindowMPS(circshift(ψ, -left_edge), FiniteMPS(ALs, ARs, ACs, CLs), circshift(ψ,-right_edge + 1))
+    return WindowMPS(circshift(ψ, -left_edge), FiniteMPS(ALs, ARs, ACs, CLs), circshift(ψ, -right_edge + 1))
 end
 
 #===========================================================================================

--- a/src/states/windowmps.jl
+++ b/src/states/windowmps.jl
@@ -106,7 +106,14 @@ function WindowMPS(N::Int, V::VectorSpace, args...; kwargs...)
     return WindowMPS(fill(V, N), args...; kwargs...)
 end
 
+"""
+    WindowMPS(ψ::InfiniteMPS, L::Int)
+    WindowMPS(ψ::InfiniteMPS, interval::UnitRange)
 
+Construct a [`WindowMPS`](@ref) from an infinite MPS `ψ` by promoting the sites in `interval`
+(or `1:L`) to the finite window while keeping `ψ` as the left and right infinite environments.
+The environment unit cells are circshifted so that they line up with the window boundaries.
+"""
 WindowMPS(ψ::InfiniteMPS, L::Int) = WindowMPS(ψ, 1:L)
 
 function WindowMPS(ψ::InfiniteMPS{A, B}, interval::UnitRange) where {A, B}

--- a/test/algorithms/dynamical_dmrg.jl
+++ b/test/algorithms/dynamical_dmrg.jl
@@ -38,15 +38,15 @@ end
     N = 20
 
     H = transverse_field_ising(g = -4)
-    Ω = InfiniteMPS(ComplexSpace(2),ComplexSpace(20))
+    Ω = InfiniteMPS(ComplexSpace(2), ComplexSpace(20))
 
-    (Ω,_) = find_groundstate(Ω, H, VUMPS(verbosity = verbosity_conv))
-    XΩ = WindowMPS(Ω,N)
-    H_w = WindowMPOHamiltonian(H,1:N)
-    
+    (Ω, _) = find_groundstate(Ω, H, VUMPS(verbosity = verbosity_conv))
+    XΩ = WindowMPS(Ω, N)
+    H_w = WindowMPOHamiltonian(H, 1:N)
 
-    gs_en =  expectation_value(XΩ, H_w)
-    vals = range(gs_en - 1.0,gs_en+1.0, length=5)
+
+    gs_en = expectation_value(XΩ, H_w)
+    vals = range(gs_en - 1.0, gs_en + 1.0, length = 5)
     eta = 0.3im
     predicted = [1 / (v + eta - gs_en) for v in vals]
 

--- a/test/algorithms/dynamical_dmrg.jl
+++ b/test/algorithms/dynamical_dmrg.jl
@@ -12,7 +12,7 @@ using TensorKit: ℙ
 
 verbosity_conv = 1
 
-@testset "Dynamical DMRG" verbose = true begin
+@testset "Dynamical DMRG FiniteMPS" verbose = true begin
     L = 10
     H = force_planar(-transverse_field_ising(; L, g = -4))
     gs, = find_groundstate(FiniteMPS(L, ℙ^2, ℙ^10), H; verbosity = verbosity_conv)
@@ -32,3 +32,32 @@ verbosity_conv = 1
         @test data ≈ predicted atol = 1.0e-8
     end
 end
+
+
+@testset "Dynamical DMRG WindowMPS" verbose = true begin
+    N = 20
+
+    H = transverse_field_ising(g = -4)
+    Ω = InfiniteMPS(ComplexSpace(2),ComplexSpace(20))
+
+    (Ω,_) = find_groundstate(Ω, H, VUMPS(verbosity = verbosity_conv))
+    XΩ = WindowMPS(Ω,N)
+    H_w = WindowMPOHamiltonian(H,1:N)
+    
+
+    gs_en =  expectation_value(XΩ, H_w)
+    vals = range(gs_en - 1.0,gs_en+1.0, length=5)
+    eta = 0.3im
+    predicted = [1 / (v + eta - gs_en) for v in vals]
+
+
+    @testset "Flavour $f" for f in (Jeckelmann(), NaiveInvert())
+        alg = DynamicalDMRG(; flavour = f, verbosity = 0, tol = 1.0e-8)
+        data = map(vals) do v
+            result, = propagator(XΩ, v + eta, H_w, alg)
+            return result
+        end
+        @test data ≈ predicted atol = 1.0e-8
+    end
+end
+

--- a/test/operators/windowhamiltonian.jl
+++ b/test/operators/windowhamiltonian.jl
@@ -1,0 +1,47 @@
+println("
+---------------------------------
+|   WindowMPOHamiltonian tests   |
+---------------------------------
+")
+
+using .TestSetup
+using Test, TestExtras
+using MPSKit
+using TensorKit
+using TensorKit: ℙ
+
+@testset "WindowMPOHamiltonian" begin
+    # a uniform state, represented with a two-site unit cell, so that carving out a window
+    # at different offsets exercises the (non-trivial) circshift alignment of the infinite
+    # environments while the physics stays translationally invariant.
+    H1 = force_planar(transverse_field_ising(; g = 1.5))
+    gs1, = find_groundstate(InfiniteMPS([ℙ^2], [ℙ^12]), H1, VUMPS(; verbosity = 0))
+    gs = repeat(gs1, 2)
+    H = repeat(H1, 2)
+
+    L = 6
+
+    @testset "interval offset (circshift)" begin
+        # the window energy must be independent of the offset for a uniform state
+        energies = map((1:L, 2:(L + 1), 3:(L + 2))) do interval
+            ψ = WindowMPS(gs, interval)
+            Hw = WindowMPOHamiltonian(H, interval)
+            @test length(Hw) == length(interval)
+            return expectation_value(ψ, Hw)
+        end
+        @test energies[1] ≈ energies[2] atol = 1.0e-8
+        @test energies[1] ≈ energies[3] atol = 1.0e-8
+    end
+
+    @testset "linear algebra" begin
+        ψ = WindowMPS(gs, 1:L)
+        Hw = WindowMPOHamiltonian(H, 1:L)
+        e = expectation_value(ψ, Hw)
+
+        @test expectation_value(ψ, Hw + Hw) ≈ 2 * e atol = 1.0e-8
+        @test expectation_value(ψ, Hw - Hw) ≈ 0 atol = 1.0e-8
+        @test expectation_value(ψ, 3 * Hw) ≈ 3 * e atol = 1.0e-8
+        @test expectation_value(ψ, Hw * 3) ≈ 3 * e atol = 1.0e-8
+        @test expectation_value(ψ, -Hw) ≈ -e atol = 1.0e-8
+    end
+end

--- a/test/operators/windowhamiltonian.jl
+++ b/test/operators/windowhamiltonian.jl
@@ -44,4 +44,20 @@ using TensorKit: ℙ
         @test expectation_value(ψ, Hw * 3) ≈ 3 * e atol = 1.0e-8
         @test expectation_value(ψ, -Hw) ≈ -e atol = 1.0e-8
     end
+
+    @testset "distinct summands" begin
+        # add two genuinely different Hamiltonians: the ZZ Ising string has a single bulk
+        # level while the XY hopping needs two, so the boundary/bulk virtual spaces of the
+        # two summands differ and have to be block-diagonalized consistently.
+        ψ = WindowMPS(gs1, 1:L)
+        Ha = WindowMPOHamiltonian(H1, 1:L)
+        Hb = WindowMPOHamiltonian(force_planar(XY_model(; g = 0.7)), 1:L)
+        @test right_virtualspace(Ha.finite_ham, 3) != right_virtualspace(Hb.finite_ham, 3)
+
+        ea = expectation_value(ψ, Ha)
+        eb = expectation_value(ψ, Hb)
+        @test expectation_value(ψ, Ha + Hb) ≈ ea + eb atol = 1.0e-8
+        @test expectation_value(ψ, Hb + Ha) ≈ ea + eb atol = 1.0e-8
+        @test expectation_value(ψ, Ha - Hb) ≈ ea - eb atol = 1.0e-8
+    end
 end

--- a/test/states/windowmps.jl
+++ b/test/states/windowmps.jl
@@ -63,14 +63,15 @@ using TensorKit: ℙ
 
     e1 = expectation_value(window, (2, 3) => O)
 
-    window, envs, _ = find_groundstate(window, ham, DMRG(; verbosity = 0))
+    w_ham = WindowMPOHamiltonian(ham,1:length(window))
+    window, envs, _ = find_groundstate(window, w_ham, DMRG(; verbosity = 0))
 
     e2 = expectation_value(window, (2, 3) => O)
 
     @test real(e2) ≤ real(e1)
 
-    window, envs = timestep(window, ham, 0.1, 0.0, TDVP2(; trscheme = truncrank(20)), envs)
-    window, envs = timestep(window, ham, 0.1, 0.0, TDVP(), envs)
+    window, envs = timestep(window, w_ham, 0.1, 0.0, TDVP2(; trscheme = truncrank(20)), envs)
+    window, envs = timestep(window, w_ham, 0.1, 0.0, TDVP(), envs)
 
     e3 = expectation_value(window, (2, 3) => O)
 

--- a/test/states/windowmps.jl
+++ b/test/states/windowmps.jl
@@ -63,7 +63,7 @@ using TensorKit: ℙ
 
     e1 = expectation_value(window, (2, 3) => O)
 
-    w_ham = WindowMPOHamiltonian(ham,1:length(window))
+    w_ham = WindowMPOHamiltonian(ham, 1:length(window))
     window, envs, _ = find_groundstate(window, w_ham, DMRG(; verbosity = 0))
 
     e2 = expectation_value(window, (2, 3) => O)


### PR DESCRIPTION
Adds a `WindowMPOHamiltonian`: the operator counterpart of a `WindowMPS`, a finite window embedded between infinite left/right "bath" Hamiltonians.
This resolves the pain points from #411, where `propagator`/dynamical DMRG could not run on a `WindowMPS`.

## What was wrong

A `WindowMPS` has a finite window but infinite environments.
Slicing an `InfiniteMPOHamiltonian` into a `FiniteMPOHamiltonian` does not impose trivial finite boundary conditions, so `environments`/`squaredenvs` hit a `SpaceMismatch`.
There was also no finite energy reference for `z` (the true ground-state energy is extensive).

## What this adds

- `WindowMPOHamiltonian(H::InfiniteMPOHamiltonian, interval)` — carves a finite window out of an infinite Hamiltonian, keeping the boundary Hamiltonians and circshifting their unit cells to align with the window.
- `environments(::WindowMPS, ::WindowMPOHamiltonian)` — builds finite env caches with boundaries from the infinite fixed-points; explicit `leftstart`/`rightstart` avoid the fixed-point solve for `conj(H)*H`.
- `propagator`/`squaredenvs` accept a `WindowMPS` + `WindowMPOHamiltonian` directly; docstrings corrected to the `1/(z-H)` convention and Jeckelmann functional (14).
- `expectation_value`, `dot`, and linear algebra (`+`, `-`, `*`, `scale`, `conj`) for `WindowMPOHamiltonian`; `WindowMPS(ψ, interval)` constructor with aligned environments.
- Window derivatives (`AC_hamiltonian`/`AC2_hamiltonian`) forward to the finite window so DMRG/TDVP/propagator use the Jordan-optimized operators.
- Tests: dynamical DMRG on a `WindowMPS` (both flavours, vs analytic result), window-Hamiltonian linear algebra + circshift-offset invariance, and `find_groundstate`/`timestep` on windows.

## Remaining work / limitations

- Full `AbstractMPO` interface coverage (only the pieces used here are wired).
- Only `InfiniteMPOHamiltonian` windows (no dense-MPO windows yet).
- No public environment-passing overload for `propagator`.
- No dedicated docs page / rendered example yet.

Closes #411
