### PR TITLE
Release v0.13.11

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
   orcid: "https://orcid.org/0000-0002-0858-291X"
 
 title: "MPSKit"
-version: 0.13.10
+version: 0.13.11
 doi: 10.5281/zenodo.10654900
-date-released: 2026-02-26
+date-released: 2026-05-04
 url: "https://github.com/QuantumKitHub/MPSKit.jl"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MPSKit"
 uuid = "bb1c41ca-d63c-52ed-829e-0820dda26502"
-version = "0.13.10"
+version = "0.13.11"
 authors = "Lukas Devos, Maarten Van Damme and contributors"
 
 [deps]

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -52,8 +52,6 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 - Various fixes for compatibility with latest TensorKit versions ([#416](https://github.com/QuantumKitHub/MPSKit.jl/pull/416))
 - `changebonds` inconsistencies ([#415](https://github.com/QuantumKitHub/MPSKit.jl/pull/415))
 - Small fixes for density operators ([#409](https://github.com/QuantumKitHub/MPSKit.jl/pull/409))
-- Issue with wrong leg fusers ([#405](https://github.com/QuantumKitHub/MPSKit.jl/pull/405))
-- Type piracy issue
 - Tolerance on positivity test ([#398](https://github.com/QuantumKitHub/MPSKit.jl/pull/398))
 
 ### Performance

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -17,7 +17,7 @@ When making changes to this project, please update the "Unreleased" section with
 
 When releasing a new version, move the "Unreleased" changes to a new version section with the release date.
 
-## [Unreleased](https://github.com/QuantumKitHub/MPSKit.jl/compare/v0.13.10...HEAD)
+## [Unreleased](https://github.com/QuantumKitHub/MPSKit.jl/compare/v0.13.11...HEAD)
 
 ### Added
 
@@ -28,6 +28,37 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 ### Removed
 
 ### Fixed
+
+### Performance
+
+## [0.13.11](https://github.com/QuantumKitHub/MPSKit.jl/compare/v0.13.10...v0.13.11) - 2026-05-04
+
+### Added
+
+- `MultilineMPO` space getters ([#407](https://github.com/QuantumKitHub/MPSKit.jl/pull/407))
+
+### Changed
+
+- Refactored time-evolution MPO construction ([#422](https://github.com/QuantumKitHub/MPSKit.jl/pull/422))
+- Updated `TensorKitManifolds` compat to 0.8 ([#421](https://github.com/QuantumKitHub/MPSKit.jl/pull/421))
+- Updated MatrixAlgebraKit algorithm specification ([#418](https://github.com/QuantumKitHub/MPSKit.jl/pull/418))
+- Preparations for GPU / non-CPU array support ([#375](https://github.com/QuantumKitHub/MPSKit.jl/pull/375), [#392](https://github.com/QuantumKitHub/MPSKit.jl/pull/392))
+- Generalized `calc_galerkin` to `AbstractMPS` ([#395](https://github.com/QuantumKitHub/MPSKit.jl/pull/395))
+- Removed explicit call to `InfiniteMPS` in VUMPS ([#396](https://github.com/QuantumKitHub/MPSKit.jl/pull/396))
+- Generalized `regauge!` to `AbstractVector` ([#393](https://github.com/QuantumKitHub/MPSKit.jl/pull/393))
+
+### Fixed
+
+- Various fixes for compatibility with latest TensorKit versions ([#416](https://github.com/QuantumKitHub/MPSKit.jl/pull/416))
+- `changebonds` inconsistencies ([#415](https://github.com/QuantumKitHub/MPSKit.jl/pull/415))
+- Small fixes for density operators ([#409](https://github.com/QuantumKitHub/MPSKit.jl/pull/409))
+- Issue with wrong leg fusers ([#405](https://github.com/QuantumKitHub/MPSKit.jl/pull/405))
+- Type piracy issue
+- Tolerance on positivity test ([#398](https://github.com/QuantumKitHub/MPSKit.jl/pull/398))
+
+### Performance
+
+- Benchmarks and AC/AC2 contraction improvements ([#345](https://github.com/QuantumKitHub/MPSKit.jl/pull/345))
 
 ## [0.13.10](https://github.com/QuantumKitHub/MPSKit.jl/compare/v0.13.9...v0.13.10) - 2026-02-26
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,9 +7,10 @@ BlockTensorKit = "5f87ffc2-9cf1-4a46-8172-465d160bd8cd"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MatrixAlgebraKit = "6c742aac-3347-4629-af66-fc926824e5e4"
 MPSKit = "bb1c41ca-d63c-52ed-829e-0820dda26502"
+MatrixAlgebraKit = "6c742aac-3347-4629-af66-fc926824e5e4"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorKitTensors = "41b62e7d-e9d1-4e23-942c-79a97adf954b"
@@ -18,16 +19,17 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
+[sources]
+MPSKit = {path = ".."}
+
 [compat]
 Aqua = "0.8.9"
 CUDA = "5.9"
 Combinatorics = "1"
 ParallelTestRunner = "2"
 Plots = "1.40"
+Pkg = "1"
 TensorKitTensors = "0.2"
 Test = "1"
 TestExtras = "0.3"
 cuTENSOR = "2.3"
-
-[sources]
-MPSKit = {path = ".."}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
 using ParallelTestRunner
 using MPSKit
+using Pkg
+
+Pkg.precompile()
 
 # Start with autodiscovered tests
 testsuite = find_tests(@__DIR__)


### PR DESCRIPTION
## MPSKit.jl v0.13.11

A maintenance release with notable performance improvements to core contraction routines, alongside TensorKit / TensorKitManifolds / MatrixAlgebraKit compatibility updates, GPU groundwork, and a number of bug fixes.

### Highlights
- **Performance**: AC and AC2 contraction routines have been optimized, reducing allocations and runtime in DMRG/VUMPS hot loops; a benchmark suite has also been added to track this going forward ([#345](https://github.com/QuantumKitHub/MPSKit.jl/pull/345))
- Preparations for GPU / non-CPU array support ([#375](https://github.com/QuantumKitHub/MPSKit.jl/pull/375), [#392](https://github.com/QuantumKitHub/MPSKit.jl/pull/392))
- Refactored time-evolution MPO construction ([#422](https://github.com/QuantumKitHub/MPSKit.jl/pull/422))
- Compat bumps for TensorKit, TensorKitManifolds 0.8, and MatrixAlgebraKit ([#416](https://github.com/QuantumKitHub/MPSKit.jl/pull/416), [#421](https://github.com/QuantumKitHub/MPSKit.jl/pull/421), [#418](https://github.com/QuantumKitHub/MPSKit.jl/pull/418))

### Full Changelog
See [CHANGELOG](https://github.com/QuantumKitHub/MPSKit.jl/blob/main/docs/src/changelog.md#01311---2026-05-04) for the complete list of changes.