### PR TITLE
Add TimerOutputs instrumentation to ground-state algorithms

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "bb1c41ca-d63c-52ed-829e-0820dda26502"
 version = "0.13.12"
 authors = "Lukas Devos, Maarten Van Damme and contributors"
 
+[workspace]
+projects = ["test", "docs"]
+
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 BlockTensorKit = "5f87ffc2-9cf1-4a46-8172-465d160bd8cd"
@@ -21,6 +24,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorKitManifolds = "11fa318c-39cb-4a83-b1ed-cdc7ba1e3684"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 
 [weakdeps]
@@ -28,9 +32,6 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 
 [extensions]
 MPSKitAdaptExt = "Adapt"
-
-[workspace]
-projects = ["test", "docs"]
 
 [compat]
 Accessors = "0.1"
@@ -51,5 +52,6 @@ RecipesBase = "1.1"
 TensorKit = "0.16.5"
 TensorKitManifolds = "0.7, 0.8"
 TensorOperations = "5.5.1"
+TimerOutputs = "0.5.29"
 VectorInterface = "0.2, 0.3, 0.4, 0.5"
 julia = "1.10"

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -85,7 +85,7 @@ using Random
 using Base: @kwdef, @propagate_inbounds
 using LoggingExtras
 using OhMyThreads
-using TimerOutputs: TimerOutput, @timeit, reset_timer!, disable_timer!, enable_timer!
+using TimerOutputs: TimerOutput, @timeit, timeit, reset_timer!, disable_timer!, enable_timer!
 
 # Includes
 # --------

--- a/src/MPSKit.jl
+++ b/src/MPSKit.jl
@@ -85,6 +85,7 @@ using Random
 using Base: @kwdef, @propagate_inbounds
 using LoggingExtras
 using OhMyThreads
+using TimerOutputs: TimerOutput, @timeit, reset_timer!, disable_timer!, enable_timer!
 
 # Includes
 # --------

--- a/src/algorithms/algorithm.jl
+++ b/src/algorithms/algorithm.jl
@@ -20,3 +20,13 @@ function Base.show(io::IO, ::MIME"text/plain", alg::Algorithm)
     end
     return nothing
 end
+
+# TIMEROUTPUT utility
+# -------------------
+# Shared sentinel passed as the default `timeroutput` kwarg by functions that optionally accept a timer.
+# `@timeit` is a no-op when the destination timer is disabled, so unrelated callers pay no instrumentation cost.
+# The merge sites that mutate `timeroutput` must gate on `timeroutput.enabled` so they don't pollute this shared object.
+const DISABLED_TIMER = let t = TimerOutput("DISABLED")
+    disable_timer!(t)
+    t
+end

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -12,7 +12,7 @@ module GrassmannMPS
 
 using ..MPSKit
 using ..MPSKit: AbstractMPSEnvironments, InfiniteEnvironments, MultilineEnvironments,
-    AC_projection, recalculate!
+    AC_projection, recalculate!, TimerOutput, DISABLED_TIMER, @timeit
 using TensorKit
 using OhMyThreads
 import TensorKitManifolds.Grassmann
@@ -143,11 +143,12 @@ Compute the cost function and the tangent vector with respect to the `AL` parame
 """
 function fg(
         state::FiniteMPS, operator::Union{O, LazySum{O}},
-        envs::AbstractMPSEnvironments = environments(state, operator)
+        envs::AbstractMPSEnvironments = environments(state, operator);
+        timeroutput::TimerOutput = DISABLED_TIMER,
     ) where {O <: FiniteMPOHamiltonian}
-    f = expectation_value(state, operator, envs)
+    f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
-    gs = map(1:length(state)) do i
+    gs = @timeit timeroutput "gradient" map(1:length(state)) do i
         AC′ = AC_projection(i, state, operator, state, envs)
         g = Grassmann.project(AC′, state.AL[i])
         return rmul(g, state.C[i]')
@@ -156,15 +157,18 @@ function fg(
 end
 function fg(
         state::InfiniteMPS, operator::Union{O, LazySum{O}},
-        envs::AbstractMPSEnvironments = environments(state, operator)
+        envs::AbstractMPSEnvironments = environments(state, operator);
+        timeroutput::TimerOutput = DISABLED_TIMER,
     ) where {O <: InfiniteMPOHamiltonian}
-    recalculate!(envs, state, operator, state)
-    f = expectation_value(state, operator, envs)
+    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 
     A = Core.Compiler.return_type(Grassmann.project, Tuple{eltype(state), eltype(state)})
     gs = Vector{A}(undef, length(state))
-    tmap!(gs, 1:length(state); scheduler = MPSKit.Defaults.scheduler[]) do i
+    @timeit timeroutput "gradient" tmap!(
+        gs, 1:length(state); scheduler = MPSKit.Defaults.scheduler[]
+    ) do i
         AC′ = AC_projection(i, state, operator, state, envs)
         g = Grassmann.project(AC′, state.AL[i])
         return rmul(g, state.C[i]')
@@ -173,15 +177,18 @@ function fg(
 end
 function fg(
         state::InfiniteMPS, operator::Union{O, LazySum{O}},
-        envs::AbstractMPSEnvironments = environments(state, operator)
+        envs::AbstractMPSEnvironments = environments(state, operator);
+        timeroutput::TimerOutput = DISABLED_TIMER,
     ) where {O <: InfiniteMPO}
-    recalculate!(envs, state, operator, state)
-    f = expectation_value(state, operator, envs)
+    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 
     A = Core.Compiler.return_type(Grassmann.project, Tuple{eltype(state), eltype(state)})
     gs = Vector{A}(undef, length(state))
-    tmap!(gs, eachindex(state); scheduler = MPSKit.Defaults.scheduler[]) do i
+    @timeit timeroutput "gradient" tmap!(
+        gs, eachindex(state); scheduler = MPSKit.Defaults.scheduler[]
+    ) do i
         AC′ = AC_projection(i, state, operator, state, envs)
         g = rmul!(Grassmann.project(AC′, state.AL[i]), -inv(f))
         return rmul(g, state.C[i]')
@@ -190,16 +197,19 @@ function fg(
 end
 function fg(
         state::MultilineMPS, operator::MultilineMPO,
-        envs::MultilineEnvironments = environments(state, operator)
+        envs::MultilineEnvironments = environments(state, operator);
+        timeroutput::TimerOutput = DISABLED_TIMER,
     )
     @assert length(state) == 1 "not implemented"
-    recalculate!(envs, state, operator, state)
-    f = expectation_value(state, operator, envs)
+    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 
     A = Core.Compiler.return_type(Grassmann.project, Tuple{eltype(state), eltype(state)})
     gs = Matrix{A}(undef, size(state))
-    tforeach(eachindex(state); scheduler = MPSKit.Defaults.scheduler[]) do i
+    @timeit timeroutput "gradient" tforeach(
+        eachindex(state); scheduler = MPSKit.Defaults.scheduler[]
+    ) do i
         AC′ = AC_projection(i, state, operator, state, envs)
         g = rmul!(Grassmann.project(AC′, state.AL[i]), -inv(f))
         gs[i] = rmul(g, state.C[i]')

--- a/src/algorithms/grassmann.jl
+++ b/src/algorithms/grassmann.jl
@@ -160,7 +160,7 @@ function fg(
         envs::AbstractMPSEnvironments = environments(state, operator);
         timeroutput::TimerOutput = DISABLED_TIMER,
     ) where {O <: InfiniteMPOHamiltonian}
-    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    @timeit timeroutput "envs (parallel)" recalculate!(envs, state, operator, state; timeroutput)
     f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 
@@ -180,7 +180,7 @@ function fg(
         envs::AbstractMPSEnvironments = environments(state, operator);
         timeroutput::TimerOutput = DISABLED_TIMER,
     ) where {O <: InfiniteMPO}
-    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    @timeit timeroutput "envs (parallel)" recalculate!(envs, state, operator, state; timeroutput)
     f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 
@@ -201,7 +201,7 @@ function fg(
         timeroutput::TimerOutput = DISABLED_TIMER,
     )
     @assert length(state) == 1 "not implemented"
-    @timeit timeroutput "envs" recalculate!(envs, state, operator, state; timeroutput)
+    @timeit timeroutput "envs (parallel)" recalculate!(envs, state, operator, state; timeroutput)
     f = @timeit timeroutput "expval" expectation_value(state, operator, envs)
     isapprox(imag(f), 0; atol = eps(abs(f))^(3 / 4)) || @warn "MPO might not be Hermitian: $f"
 

--- a/src/algorithms/groundstate/dmrg.jl
+++ b/src/algorithms/groundstate/dmrg.jl
@@ -36,6 +36,8 @@ function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG, envs = environme
     ϵs = map(pos -> calc_galerkin(pos, ψ, H, ψ, envs), 1:length(ψ))
     ϵ = maximum(ϵs)
     log = IterLog("DMRG")
+    timeroutput = TimerOutput("DMRG")
+    alg.verbosity > 3 || disable_timer!(timeroutput)
 
     LoggingExtras.withlevel(; alg.verbosity) do
         @infov 2 loginit!(log, ϵ, expectation_value(ψ, H, envs))
@@ -43,21 +45,30 @@ function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG, envs = environme
             alg_eigsolve = updatetol(alg.alg_eigsolve, iter, ϵ)
 
             zerovector!(ϵs)
-            for pos in [1:(length(ψ) - 1); length(ψ):-1:2]
-                h = AC_hamiltonian(pos, ψ, H, ψ, envs)
-                _, vec = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
-                ϵs[pos] = max(ϵs[pos], calc_galerkin(pos, ψ, H, ψ, envs))
-                ψ.AC[pos] = vec
+            @timeit timeroutput "sweep" begin
+                for pos in [1:(length(ψ) - 1); length(ψ):-1:2]
+                    local vec
+                    @timeit timeroutput "AC_eigsolve" begin
+                        h = AC_hamiltonian(pos, ψ, H, ψ, envs)
+                        _, vec = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
+                    end
+                    ϵs[pos] = max(ϵs[pos], calc_galerkin(pos, ψ, H, ψ, envs))
+                    @timeit timeroutput "AC_update" ψ.AC[pos] = vec
+                end
             end
             ϵ = maximum(ϵs)
 
-            ψ, envs = alg.finalize(iter, ψ, H, envs)::Tuple{typeof(ψ), typeof(envs)}
+            ψ, envs = @timeit timeroutput "finalize" alg.finalize(
+                iter, ψ, H, envs
+            )::Tuple{typeof(ψ), typeof(envs)}
 
             if ϵ <= alg.tol
+                @infov 4 timeroutput
                 @infov 2 logfinish!(log, iter, ϵ, expectation_value(ψ, H, envs))
                 break
             end
             if iter == alg.maxiter
+                @infov 4 timeroutput
                 @warnv 1 logcancel!(log, iter, ϵ, expectation_value(ψ, H, envs))
             else
                 @infov 3 logiter!(log, iter, ϵ, expectation_value(ψ, H, envs))
@@ -113,50 +124,68 @@ function find_groundstate!(ψ::AbstractFiniteMPS, H, alg::DMRG2, envs = environm
     ϵs = map(pos -> calc_galerkin(pos, ψ, H, ψ, envs), 1:length(ψ))
     ϵ = maximum(ϵs)
     log = IterLog("DMRG2")
+    timeroutput = TimerOutput("DMRG2")
+    alg.verbosity > 3 || disable_timer!(timeroutput)
 
     LoggingExtras.withlevel(; alg.verbosity) do
         for iter in 1:(alg.maxiter)
             alg_eigsolve = updatetol(alg.alg_eigsolve, iter, ϵ)
             zerovector!(ϵs)
 
-            # left to right sweep
-            for pos in 1:(length(ψ) - 1)
-                @plansor ac2[-1 -2; -3 -4] := ψ.AC[pos][-1 -2; 1] * ψ.AR[pos + 1][1 -4; -3]
-                Hac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
-                _, newA2center = fixedpoint(Hac2, ac2, :SR, alg_eigsolve)
+            @timeit timeroutput "sweep" begin
+                # left to right sweep
+                for pos in 1:(length(ψ) - 1)
+                    local ac2, newA2center, al, c, ar
+                    @timeit timeroutput "AC2_eigsolve" begin
+                        @plansor ac2[-1 -2; -3 -4] := ψ.AC[pos][-1 -2; 1] * ψ.AR[pos + 1][1 -4; -3]
+                        Hac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
+                        _, newA2center = fixedpoint(Hac2, ac2, :SR, alg_eigsolve)
+                    end
+                    @timeit timeroutput "svd_trunc" begin
+                        al, c, ar = svd_trunc!(newA2center; trunc = alg.trscheme, alg = alg.alg_svd)
+                        normalize!(c)
+                        v = @plansor ac2[1 2; 3 4] * conj(al[1 2; 5]) * conj(c[5; 6]) * conj(ar[6; 3 4])
+                        ϵs[pos] = max(ϵs[pos], abs(1 - abs(v)))
+                    end
+                    @timeit timeroutput "update_AC" begin
+                        ψ.AC[pos] = (al, complex(c))
+                        ψ.AC[pos + 1] = (complex(c), _transpose_front(ar))
+                    end
+                end
 
-                al, c, ar = svd_trunc!(newA2center; trunc = alg.trscheme, alg = alg.alg_svd)
-                normalize!(c)
-                v = @plansor ac2[1 2; 3 4] * conj(al[1 2; 5]) * conj(c[5; 6]) * conj(ar[6; 3 4])
-                ϵs[pos] = max(ϵs[pos], abs(1 - abs(v)))
-
-                ψ.AC[pos] = (al, complex(c))
-                ψ.AC[pos + 1] = (complex(c), _transpose_front(ar))
-            end
-
-            # right to left sweep
-            for pos in (length(ψ) - 2):-1:1
-                @plansor ac2[-1 -2; -3 -4] := ψ.AL[pos][-1 -2; 1] * ψ.AC[pos + 1][1 -4; -3]
-                Hac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
-                _, newA2center = fixedpoint(Hac2, ac2, :SR, alg_eigsolve)
-
-                al, c, ar = svd_trunc!(newA2center; trunc = alg.trscheme, alg = alg.alg_svd)
-                normalize!(c)
-                v = @plansor ac2[1 2; 3 4] * conj(al[1 2; 5]) * conj(c[5; 6]) * conj(ar[6; 3 4])
-                ϵs[pos] = max(ϵs[pos], abs(1 - abs(v)))
-
-                ψ.AC[pos + 1] = (complex(c), _transpose_front(ar))
-                ψ.AC[pos] = (al, complex(c))
+                # right to left sweep
+                for pos in (length(ψ) - 2):-1:1
+                    local ac2, newA2center, al, c, ar
+                    @timeit timeroutput "AC2_eigsolve" begin
+                        @plansor ac2[-1 -2; -3 -4] := ψ.AL[pos][-1 -2; 1] * ψ.AC[pos + 1][1 -4; -3]
+                        Hac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
+                        _, newA2center = fixedpoint(Hac2, ac2, :SR, alg_eigsolve)
+                    end
+                    @timeit timeroutput "svd_trunc" begin
+                        al, c, ar = svd_trunc!(newA2center; trunc = alg.trscheme, alg = alg.alg_svd)
+                        normalize!(c)
+                        v = @plansor ac2[1 2; 3 4] * conj(al[1 2; 5]) * conj(c[5; 6]) * conj(ar[6; 3 4])
+                        ϵs[pos] = max(ϵs[pos], abs(1 - abs(v)))
+                    end
+                    @timeit timeroutput "update_AC" begin
+                        ψ.AC[pos + 1] = (complex(c), _transpose_front(ar))
+                        ψ.AC[pos] = (al, complex(c))
+                    end
+                end
             end
 
             ϵ = maximum(ϵs)
-            ψ, envs = alg.finalize(iter, ψ, H, envs)::Tuple{typeof(ψ), typeof(envs)}
+            ψ, envs = @timeit timeroutput "finalize" alg.finalize(
+                iter, ψ, H, envs
+            )::Tuple{typeof(ψ), typeof(envs)}
 
             if ϵ <= alg.tol
+                @infov 4 timeroutput
                 @infov 2 logfinish!(log, iter, ϵ, expectation_value(ψ, H, envs))
                 break
             end
             if iter == alg.maxiter
+                @infov 4 timeroutput
                 @warnv 1 logcancel!(log, iter, ϵ, expectation_value(ψ, H, envs))
             else
                 @infov 3 logiter!(log, iter, ϵ, expectation_value(ψ, H, envs))

--- a/src/algorithms/groundstate/gradient_grassmann.jl
+++ b/src/algorithms/groundstate/gradient_grassmann.jl
@@ -62,17 +62,34 @@ function find_groundstate(
         @warn "This is not fully supported - split the mps up in a sum of mps's and optimize separately"
     normalize!(ψ)
 
-    fg(x) = GrassmannMPS.fg(x, H, envs)
+    timeroutput = TimerOutput("GradientGrassmann")
+    method_verbosity = hasproperty(alg.method, :verbosity) ? alg.method.verbosity : 0
+    method_verbosity > 3 || disable_timer!(timeroutput)
+
+    fg(x) = timeit(() -> GrassmannMPS.fg(x, H, envs; timeroutput), timeroutput, "fg")
+    retract(state, g, α) = timeit(
+        () -> GrassmannMPS.retract(state, g, α), timeroutput, "retract",
+    )
+    transport!(h, state, g, α, state′) = timeit(
+        () -> GrassmannMPS.transport!(h, state, g, α, state′), timeroutput, "transport!",
+    )
+    precondition(state, g) = timeit(
+        () -> GrassmannMPS.precondition(state, g), timeroutput, "precondition",
+    )
+
     x, _, _, _, normgradhistory = optimize(
         fg, ψ, alg.method;
-        GrassmannMPS.transport!,
-        GrassmannMPS.retract,
+        retract, transport!, precondition,
         GrassmannMPS.inner,
         GrassmannMPS.scale!,
         GrassmannMPS.add!,
-        GrassmannMPS.precondition,
         alg.finalize!,
-        isometrictransport = true
+        isometrictransport = true,
     )
+
+    LoggingExtras.withlevel(; verbosity = method_verbosity) do
+        @infov 4 timeroutput
+    end
+
     return x, envs, normgradhistory[end]
 end

--- a/src/algorithms/groundstate/idmrg.jl
+++ b/src/algorithms/groundstate/idmrg.jl
@@ -65,14 +65,21 @@ struct IDMRGState{S, O, E, T}
     iter::Int
     ϵ::Float64 # TODO: Could be any <:Real
     energy::T
+    timeroutput::TimerOutput
 end
-function IDMRGState{T}(mps::S, operator::O, envs::E, iter::Int, ϵ::Float64, energy) where {S, O, E, T}
-    return IDMRGState{S, O, E, T}(mps, operator, envs, iter, ϵ, T(energy))
+function IDMRGState{T}(
+        mps::S, operator::O, envs::E, iter::Int, ϵ::Float64, energy,
+        timeroutput::TimerOutput,
+    ) where {S, O, E, T}
+    return IDMRGState{S, O, E, T}(mps, operator, envs, iter, ϵ, T(energy), timeroutput)
 end
 
 function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps, operator)) where {alg_type <: Union{<:IDMRG, <:IDMRG2}}
     (length(mps) ≤ 1 && alg isa IDMRG2) && throw(ArgumentError("unit cell should be >= 2"))
-    log = alg isa IDMRG ? IterLog("IDMRG") : IterLog("IDMRG2")
+    name = alg isa IDMRG ? "IDMRG" : "IDMRG2"
+    log = IterLog(name)
+    timeroutput = TimerOutput(name)
+    alg.verbosity > 3 || disable_timer!(timeroutput)
     mps = copy(mps)
     iter = 0
     ϵ = calc_galerkin(mps, operator, mps, envs)
@@ -85,16 +92,18 @@ function find_groundstate(mps, operator, alg::alg_type, envs = environments(mps,
         end
     end
 
-    state = IDMRGState(mps, operator, envs, iter, ϵ, E)
+    state = IDMRGState(mps, operator, envs, iter, ϵ, E, timeroutput)
     it = IterativeSolver(alg, state)
 
     return LoggingExtras.withlevel(; alg.verbosity) do
         for (mps, envs, ϵ, ΔE) in it
             if ϵ ≤ alg.tol
+                @infov 4 timeroutput
                 @infov 2 logfinish!(log, it.iter, ϵ, ΔE)
                 break
             end
             if it.iter ≥ alg.maxiter
+                @infov 4 timeroutput
                 @warnv 1 logcancel!(log, it.iter, ϵ, ΔE)
                 break
             end
@@ -111,7 +120,8 @@ end
 function Base.iterate(
         it::IterativeSolver{alg_type}, state::IDMRGState{<:Any, <:Any, <:Any, T} = it.state
     ) where {alg_type <: Union{<:IDMRG, <:IDMRG2}, T}
-    mps, envs, C_old, E_new = localupdate_step!(it, state)
+    timeroutput = state.timeroutput
+    mps, envs, C_old, E_new = @timeit timeroutput "localupdate" localupdate_step!(it, state)
 
     # error criterion
     C = mps.C[0]
@@ -131,7 +141,9 @@ function Base.iterate(
     (alg_type <: IDMRG2 && length(mps) == 2) && (ΔE /= 2) # This extra factor gives the correct energy per unit cell. I have no clue why right now.
 
     # update state
-    it.state = IDMRGState{T}(mps, state.operator, envs, state.iter + 1, ϵ, E_new)
+    it.state = IDMRGState{T}(
+        mps, state.operator, envs, state.iter + 1, ϵ, E_new, timeroutput,
+    )
 
     return (mps, envs, ϵ, ΔE), it.state
 end
@@ -140,125 +152,160 @@ function localupdate_step!(
         it::IterativeSolver{<:IDMRG}, state
     )
     alg_eigsolve = updatetol(it.alg_eigsolve, state.iter, state.ϵ)
-    return _localupdate_sweep_idmrg!(state.mps, state.operator, state.envs, alg_eigsolve)
+    return _localupdate_sweep_idmrg!(
+        state.mps, state.operator, state.envs, alg_eigsolve, state.timeroutput,
+    )
 end
 
 function localupdate_step!(
         it::IterativeSolver{<:IDMRG2}, state
     )
     alg_eigsolve = updatetol(it.alg_eigsolve, state.iter, state.ϵ)
-    return _localupdate_sweep_idmrg2!(state.mps, state.operator, state.envs, alg_eigsolve, it.trscheme, it.alg_svd)
+    return _localupdate_sweep_idmrg2!(
+        state.mps, state.operator, state.envs, alg_eigsolve,
+        it.trscheme, it.alg_svd, state.timeroutput,
+    )
 end
 
-function _localupdate_sweep_idmrg!(ψ, H, envs, alg_eigsolve)
+function _localupdate_sweep_idmrg!(ψ, H, envs, alg_eigsolve, timeroutput::TimerOutput)
     local E
     C_old = ψ.C[0]
     # left to right sweep
     for pos in 1:length(ψ)
-        h = AC_hamiltonian(pos, ψ, H, ψ, envs)
-        _, ψ.AC[pos] = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
-        if pos == length(ψ)
-            # AC needed in next sweep
-            ψ.AL[pos], ψ.C[pos] = left_orth(ψ.AC[pos]; positive = true)
-        else
-            ψ.AL[pos], ψ.C[pos] = left_orth!(ψ.AC[pos]; positive = true)
+        @timeit timeroutput "AC_eigsolve" begin
+            h = AC_hamiltonian(pos, ψ, H, ψ, envs)
+            _, ψ.AC[pos] = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
         end
-        transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
+        @timeit timeroutput "ortho_step" begin
+            if pos == length(ψ)
+                # AC needed in next sweep
+                ψ.AL[pos], ψ.C[pos] = left_orth(ψ.AC[pos]; positive = true)
+            else
+                ψ.AL[pos], ψ.C[pos] = left_orth!(ψ.AC[pos]; positive = true)
+            end
+        end
+        @timeit timeroutput "transfer_env" transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
     end
 
     # right to left sweep
     for pos in length(ψ):-1:1
-        h = AC_hamiltonian(pos, ψ, H, ψ, envs)
-        E, ψ.AC[pos] = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
-
-        ψ.C[pos - 1], temp = right_orth!(_transpose_tail(ψ.AC[pos]; copy = (pos == 1)); positive = true)
-        ψ.AR[pos] = _transpose_front(temp)
-
-        transfer_rightenv!(envs, ψ, H, ψ, pos - 1)
+        @timeit timeroutput "AC_eigsolve" begin
+            h = AC_hamiltonian(pos, ψ, H, ψ, envs)
+            E, ψ.AC[pos] = fixedpoint(h, ψ.AC[pos], :SR, alg_eigsolve)
+        end
+        @timeit timeroutput "ortho_step" begin
+            ψ.C[pos - 1], temp = right_orth!(_transpose_tail(ψ.AC[pos]; copy = (pos == 1)); positive = true)
+            ψ.AR[pos] = _transpose_front(temp)
+        end
+        @timeit timeroutput "transfer_env" transfer_rightenv!(envs, ψ, H, ψ, pos - 1)
     end
     return ψ, envs, C_old, E
 end
 
 
-function _localupdate_sweep_idmrg2!(ψ, H, envs, alg_eigsolve, alg_trscheme, alg_svd)
+function _localupdate_sweep_idmrg2!(
+        ψ, H, envs, alg_eigsolve, alg_trscheme, alg_svd, timeroutput::TimerOutput,
+    )
+    # @timeit wraps its body in try-finally, which is a new lexical scope: declare locals
+    # at function scope so values can flow between consecutive @timeit blocks.
+    local ac2′, c, E
     # sweep from left to right
     for pos in 1:(length(ψ) - 1)
-        ac2 = AC2(ψ, pos; kind = :ACAR)
-        h_ac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
-        _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+        @timeit timeroutput "AC2_eigsolve" begin
+            ac2 = AC2(ψ, pos; kind = :ACAR)
+            h_ac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
+            _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+        end
+        @timeit timeroutput "svd_trunc" begin
+            al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
+            normalize!(c)
 
-        al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
-        normalize!(c)
-
-        ψ.AL[pos] = al
-        ψ.C[pos] = complex(c)
-        ψ.AR[pos + 1] = _transpose_front(ar)
-        ψ.AC[pos + 1] = _transpose_front(c * ar)
-
-        transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
-        transfer_rightenv!(envs, ψ, H, ψ, pos)
+            ψ.AL[pos] = al
+            ψ.C[pos] = complex(c)
+            ψ.AR[pos + 1] = _transpose_front(ar)
+            ψ.AC[pos + 1] = _transpose_front(c * ar)
+        end
+        @timeit timeroutput "transfer_env" begin
+            transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
+            transfer_rightenv!(envs, ψ, H, ψ, pos)
+        end
     end
 
     # update the edge
     ψ.AL[end] = ψ.AC[end] / ψ.C[end]
     ψ.AC[1] = _mul_tail(ψ.AL[1], ψ.C[1])
-    ac2 = AC2(ψ, 0; kind = :ALAC)
-    h_ac2 = AC2_hamiltonian(0, ψ, H, ψ, envs)
-    _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+    @timeit timeroutput "AC2_eigsolve" begin
+        ac2 = AC2(ψ, 0; kind = :ALAC)
+        h_ac2 = AC2_hamiltonian(0, ψ, H, ψ, envs)
+        _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+    end
+    @timeit timeroutput "svd_trunc" begin
+        al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
+        normalize!(c)
 
-    al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
-    normalize!(c)
+        ψ.AL[end] = al
+        ψ.C[end] = complex(c)
+        ψ.AR[1] = _transpose_front(ar)
 
-    ψ.AL[end] = al
-    ψ.C[end] = complex(c)
-    ψ.AR[1] = _transpose_front(ar)
-
-    ψ.AC[end] = _mul_tail(al, c)
-    ψ.AC[1] = _transpose_front(c * ar)
-    ψ.AL[1] = ψ.AC[1] / ψ.C[1]
+        ψ.AC[end] = _mul_tail(al, c)
+        ψ.AC[1] = _transpose_front(c * ar)
+        ψ.AL[1] = ψ.AC[1] / ψ.C[1]
+    end
 
     C_old = complex(c)
 
     # update environments
-    transfer_leftenv!(envs, ψ, H, ψ, 1)
-    transfer_rightenv!(envs, ψ, H, ψ, 0)
+    @timeit timeroutput "transfer_env" begin
+        transfer_leftenv!(envs, ψ, H, ψ, 1)
+        transfer_rightenv!(envs, ψ, H, ψ, 0)
+    end
 
     # sweep from right to left
     for pos in (length(ψ) - 1):-1:1
-        ac2 = AC2(ψ, pos; kind = :ALAC)
-        h_ac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
-        _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+        @timeit timeroutput "AC2_eigsolve" begin
+            ac2 = AC2(ψ, pos; kind = :ALAC)
+            h_ac2 = AC2_hamiltonian(pos, ψ, H, ψ, envs)
+            _, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+        end
+        @timeit timeroutput "svd_trunc" begin
+            al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
+            normalize!(c)
 
-        al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
-        normalize!(c)
-
-        ψ.AL[pos] = al
-        ψ.AC[pos] = _mul_tail(al, c)
-        ψ.C[pos] = complex(c)
-        ψ.AR[pos + 1] = _transpose_front(ar)
-        ψ.AC[pos + 1] = _transpose_front(c * ar)
-
-        transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
-        transfer_rightenv!(envs, ψ, H, ψ, pos)
+            ψ.AL[pos] = al
+            ψ.AC[pos] = _mul_tail(al, c)
+            ψ.C[pos] = complex(c)
+            ψ.AR[pos + 1] = _transpose_front(ar)
+            ψ.AC[pos + 1] = _transpose_front(c * ar)
+        end
+        @timeit timeroutput "transfer_env" begin
+            transfer_leftenv!(envs, ψ, H, ψ, pos + 1)
+            transfer_rightenv!(envs, ψ, H, ψ, pos)
+        end
     end
 
     # update the edge
     ψ.AC[end] = _mul_front(ψ.C[end - 1], ψ.AR[end])
     ψ.AR[1] = _transpose_front(ψ.C[end] \ _transpose_tail(ψ.AC[1]))
-    ac2 = AC2(ψ, 0; kind = :ACAR)
-    h_ac2 = AC2_hamiltonian(0, ψ, H, ψ, envs)
-    E, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
-    al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
-    normalize!(c)
+    @timeit timeroutput "AC2_eigsolve" begin
+        ac2 = AC2(ψ, 0; kind = :ACAR)
+        h_ac2 = AC2_hamiltonian(0, ψ, H, ψ, envs)
+        E, ac2′ = fixedpoint(h_ac2, ac2, :SR, alg_eigsolve)
+    end
+    @timeit timeroutput "svd_trunc" begin
+        al, c, ar = svd_trunc!(ac2′; trunc = alg_trscheme, alg = alg_svd)
+        normalize!(c)
 
-    ψ.AL[end] = al
-    ψ.C[end] = complex(c)
-    ψ.AR[1] = _transpose_front(ar)
+        ψ.AL[end] = al
+        ψ.C[end] = complex(c)
+        ψ.AR[1] = _transpose_front(ar)
 
-    ψ.AR[end] = _transpose_front(ψ.C[end - 1] \ _transpose_tail(al * c))
-    ψ.AC[1] = _transpose_front(c * ar)
+        ψ.AR[end] = _transpose_front(ψ.C[end - 1] \ _transpose_tail(al * c))
+        ψ.AC[1] = _transpose_front(c * ar)
+    end
 
-    transfer_leftenv!(envs, ψ, H, ψ, 1)
-    transfer_rightenv!(envs, ψ, H, ψ, 0)
+    @timeit timeroutput "transfer_env" begin
+        transfer_leftenv!(envs, ψ, H, ψ, 1)
+        transfer_rightenv!(envs, ψ, H, ψ, 0)
+    end
     return ψ, envs, C_old, E
 end

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -43,6 +43,7 @@ struct VUMPSState{S, O, E}
     iter::Int
     ϵ::Float64
     which::Symbol
+    timeroutput::TimerOutput
 end
 
 function find_groundstate(
@@ -56,24 +57,29 @@ function dominant_eigsolve(
         which
     )
     log = IterLog("VUMPS")
+    timeroutput = TimerOutput("VUMPS")
+    alg.verbosity > 3 || disable_timer!(timeroutput)
     iter = 0
+
     mps = copy(mps)
     ϵ = calc_galerkin(mps, operator, mps, envs)
     alg_environments = updatetol(alg.alg_environments, iter, ϵ)
     recalculate!(envs, mps, operator, mps; alg_environments.tol)
 
-    state = VUMPSState(mps, operator, envs, iter, ϵ, which)
+    state = VUMPSState(mps, operator, envs, iter, ϵ, which, timeroutput)
     it = IterativeSolver(alg, state)
 
-    return LoggingExtras.withlevel(; alg.verbosity) do
+    result = LoggingExtras.withlevel(; alg.verbosity) do
         @infov 2 loginit!(log, ϵ, sum(expectation_value(mps, operator, envs)))
 
         for (mps, envs, ϵ) in it
             if ϵ ≤ alg.tol
+                @infov 4 timeroutput
                 @infov 2 logfinish!(log, it.iter, ϵ, expectation_value(mps, operator, envs))
                 return mps, envs, ϵ
             end
             if it.iter ≥ alg.maxiter
+                @infov 4 timeroutput
                 @warnv 1 logcancel!(log, it.iter, ϵ, expectation_value(mps, operator, envs))
                 return mps, envs, ϵ
             end
@@ -83,21 +89,28 @@ function dominant_eigsolve(
         # this should never be reached
         return it.state.mps, it.state.envs, it.state.ϵ
     end
+
+    return result
 end
 
 function Base.iterate(it::IterativeSolver{<:VUMPS}, state = it.state)
-    ACs = localupdate_step!(it, state)
-    mps = gauge_step!(it, state, ACs)
-    envs = envs_step!(it, state, mps)
+    timeroutput = state.timeroutput
+    ACs = @timeit timeroutput "localupdate" localupdate_step!(it, state)
+    mps = @timeit timeroutput "gauge" gauge_step!(it, state, ACs)
+    envs = @timeit timeroutput "envs" envs_step!(it, state, mps)
 
     # finalizer step
-    mps, envs = it.finalize(state.iter, mps, state.operator, envs)::typeof((mps, envs))
+    mps, envs = @timeit timeroutput "finalize" it.finalize(
+        state.iter, mps, state.operator, envs
+    )::typeof((mps, envs))
 
     # error criterion
-    ϵ = calc_galerkin(mps, state.operator, mps, envs)
+    ϵ = @timeit timeroutput "calc_galerkin" calc_galerkin(mps, state.operator, mps, envs)
 
     # update state
-    it.state = VUMPSState(mps, state.operator, envs, state.iter + 1, ϵ, state.which)
+    it.state = VUMPSState(
+        mps, state.operator, envs, state.iter + 1, ϵ, state.which, timeroutput,
+    )
 
     return (mps, envs, ϵ), it.state
 end
@@ -114,12 +127,17 @@ function localupdate_step!(
     ACs = mps.AL
     dst_ACs = mps isa Multiline ? eachcol(ACs) : ACs
 
+
+    tree_point = String[section.name for section in state.timeroutput.timer_stack]
     tforeach(eachsite(mps), src_ACs, src_Cs; scheduler) do site, AC₀, C₀
+        sub_timeroutput = TimerOutput()
         dst_ACs[site] = _localupdate_vumps_step!(
             site, mps, state.operator, state.envs, AC₀, C₀;
-            parallel = false, alg_orth, state.which, alg_eigsolve
+            parallel = false, alg_orth, state.which, alg_eigsolve,
+            timeroutput = sub_timeroutput,
         )
-        return nothing
+        state.timeroutput.enabled &&
+            merge!(state.timeroutput, sub_timeroutput; tree_point)
     end
 
     return ACs
@@ -128,25 +146,39 @@ end
 function _localupdate_vumps_step!(
         site, mps, operator, envs, AC₀, C₀;
         parallel::Bool = false, alg_orth = Defaults.alg_orth(),
-        alg_eigsolve = Defaults.eigsolver, which
+        alg_eigsolve = Defaults.eigsolver, which,
+        timeroutput::TimerOutput = DISABLED_TIMER,
     )
     if !parallel
-        Hac = AC_hamiltonian(site, mps, operator, mps, envs)
-        _, AC = fixedpoint(Hac, AC₀, which, alg_eigsolve)
-        Hc = C_hamiltonian(site, mps, operator, mps, envs)
-        _, C = fixedpoint(Hc, C₀, which, alg_eigsolve)
+        local AC, C
+        @timeit timeroutput "AC_eigsolve" begin
+            Hac = AC_hamiltonian(site, mps, operator, mps, envs)
+            _, AC = fixedpoint(Hac, AC₀, which, alg_eigsolve)
+        end
+        @timeit timeroutput "C_eigsolve" begin
+            Hc = C_hamiltonian(site, mps, operator, mps, envs)
+            _, C = fixedpoint(Hc, C₀, which, alg_eigsolve)
+        end
         return regauge!(AC, C; alg = alg_orth)
     end
 
     local AC, C
     @sync begin
         @spawn begin
-            Hac = AC_hamiltonian(site, mps, operator, mps, envs)
-            _, AC = fixedpoint(Hac, AC₀, which, alg_eigsolve)
+            sub_timeroutput = TimerOutput()
+            @timeit sub_timeroutput "AC_eigsolve" begin
+                Hac = AC_hamiltonian(site, mps, operator, mps, envs)
+                _, AC = fixedpoint(Hac, AC₀, which, alg_eigsolve)
+            end
+            timeroutput.enabled && merge!(timeroutput, sub_timeroutput)
         end
         @spawn begin
-            Hc = C_hamiltonian(site, mps, operator, mps, envs)
-            _, C = fixedpoint(Hc, C₀, which, alg_eigsolve)
+            sub_timeroutput = TimerOutput()
+            @timeit sub_timeroutput "C_eigsolve" begin
+                Hc = C_hamiltonian(site, mps, operator, mps, envs)
+                _, C = fixedpoint(Hc, C₀, which, alg_eigsolve)
+            end
+            timeroutput.enabled && merge!(timeroutput, sub_timeroutput)
         end
     end
     return regauge!(AC, C; alg = alg_orth)
@@ -156,7 +188,7 @@ function gauge_step!(it::IterativeSolver{<:VUMPS}, state, ACs::AbstractVector)
     alg_gauge = updatetol(it.alg_gauge, state.iter, state.ϵ)
     mps = gaugefix!(
         state.mps, ACs, state.mps.C[end];
-        alg_gauge.tol, alg_gauge.maxiter, order = :R
+        alg_gauge.tol, alg_gauge.maxiter, order = :R, timeroutput = state.timeroutput,
     )
     mul!.(mps.AC, mps.AL, mps.C)
     return mps
@@ -168,5 +200,8 @@ end
 
 function envs_step!(it::IterativeSolver{<:VUMPS}, state, mps)
     alg_environments = updatetol(it.alg_environments, state.iter, state.ϵ)
-    return recalculate!(state.envs, mps, state.operator, mps; alg_environments.tol)
+    return recalculate!(
+        state.envs, mps, state.operator, mps;
+        alg_environments.tol, state.timeroutput,
+    )
 end

--- a/src/algorithms/groundstate/vumps.jl
+++ b/src/algorithms/groundstate/vumps.jl
@@ -95,9 +95,9 @@ end
 
 function Base.iterate(it::IterativeSolver{<:VUMPS}, state = it.state)
     timeroutput = state.timeroutput
-    ACs = @timeit timeroutput "localupdate" localupdate_step!(it, state)
+    ACs = @timeit timeroutput "localupdate (parallel)" localupdate_step!(it, state)
     mps = @timeit timeroutput "gauge" gauge_step!(it, state, ACs)
-    envs = @timeit timeroutput "envs" envs_step!(it, state, mps)
+    envs = @timeit timeroutput "envs (parallel)" envs_step!(it, state, mps)
 
     # finalizer step
     mps, envs = @timeit timeroutput "finalize" it.finalize(

--- a/src/environments/infinite_envs.jl
+++ b/src/environments/infinite_envs.jl
@@ -51,6 +51,7 @@ function recalculate!(
         envs::InfiniteEnvironments, below::InfiniteMPS,
         operator::Union{InfiniteMPO, InfiniteMPOHamiltonian},
         above::InfiniteMPS = below;
+        timeroutput::TimerOutput = DISABLED_TIMER,
         kwargs...
     )
     if !issamespace(envs, below, operator, above)
@@ -62,9 +63,18 @@ function recalculate!(
 
     alg = environment_alg(below, operator, above; kwargs...)
 
+    tree_point = String[section.name for section in timeroutput.timer_stack]
     @sync begin
-        @spawn compute_leftenvs!(envs, below, operator, above, alg)
-        @spawn compute_rightenvs!(envs, below, operator, above, alg)
+        @spawn begin
+            sub_timeroutput = TimerOutput()
+            @timeit sub_timeroutput "left_envs" compute_leftenvs!(envs, below, operator, above, alg)
+            timeroutput.enabled && merge!(timeroutput, sub_timeroutput; tree_point)
+        end
+        @spawn begin
+            sub_timeroutput = TimerOutput()
+            @timeit sub_timeroutput "right_envs" compute_rightenvs!(envs, below, operator, above, alg)
+            timeroutput.enabled && merge!(timeroutput, sub_timeroutput; tree_point)
+        end
     end
     normalize!(envs, below, operator, above)
 

--- a/src/states/ortho.jl
+++ b/src/states/ortho.jl
@@ -98,7 +98,10 @@ Bring an `InfiniteMPS` into a uniform gauge, using the specified algorithm.
 """
 gaugefix!
 
-function gaugefix!(ψ::InfiniteMPS, A, C₀ = ψ.C[end]; order = :LR, kwargs...)
+function gaugefix!(
+        ψ::InfiniteMPS, A, C₀ = ψ.C[end];
+        order = :LR, timeroutput::TimerOutput = DISABLED_TIMER, kwargs...
+    )
     alg = if order === :LR || order === :RL
         MixedCanonical(; order, kwargs...)
     elseif order === :L
@@ -109,28 +112,37 @@ function gaugefix!(ψ::InfiniteMPS, A, C₀ = ψ.C[end]; order = :LR, kwargs...)
         throw(ArgumentError("Invalid order: $order"))
     end
 
-    return gaugefix!(ψ, A, C₀, alg)
+    return gaugefix!(ψ, A, C₀, alg; timeroutput)
 end
 
 # expert mode: actual implementation
-function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::MixedCanonical)
+function gaugefix!(
+        ψ::InfiniteMPS, A, C₀, alg::MixedCanonical;
+        timeroutput::TimerOutput = DISABLED_TIMER
+    )
     if alg.order === :LR
-        gaugefix!(ψ, A, C₀, alg.alg_leftcanonical)
-        gaugefix!(ψ, ψ.AL, ψ.C[end], alg.alg_rightcanonical)
+        gaugefix!(ψ, A, C₀, alg.alg_leftcanonical; timeroutput)
+        gaugefix!(ψ, ψ.AL, ψ.C[end], alg.alg_rightcanonical; timeroutput)
     elseif alg.order === :RL
-        gaugefix!(ψ, A, C₀, alg.alg_rightcanonical)
-        gaugefix!(ψ, ψ.AR, ψ.C[end], alg.alg_leftcanonical)
+        gaugefix!(ψ, A, C₀, alg.alg_rightcanonical; timeroutput)
+        gaugefix!(ψ, ψ.AR, ψ.C[end], alg.alg_leftcanonical; timeroutput)
     else
         throw(ArgumentError("Invalid order: $(alg.order)"))
     end
     return ψ
 end
-function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::LeftCanonical)
-    uniform_leftorth!((ψ.AL, ψ.C), A, C₀, alg)
+function gaugefix!(
+        ψ::InfiniteMPS, A, C₀, alg::LeftCanonical;
+        timeroutput::TimerOutput = DISABLED_TIMER
+    )
+    uniform_leftorth!((ψ.AL, ψ.C), A, C₀, alg; timeroutput)
     return ψ
 end
-function gaugefix!(ψ::InfiniteMPS, A, C₀, alg::RightCanonical)
-    uniform_rightorth!((ψ.AR, ψ.C), A, C₀, alg)
+function gaugefix!(
+        ψ::InfiniteMPS, A, C₀, alg::RightCanonical;
+        timeroutput::TimerOutput = DISABLED_TIMER
+    )
+    uniform_rightorth!((ψ.AR, ψ.C), A, C₀, alg; timeroutput)
     return ψ
 end
 
@@ -188,14 +200,17 @@ end
 # Implementation
 # --------------
 
-function uniform_leftorth!((AL, C), A, C₀, alg::LeftCanonical)
+function uniform_leftorth!(
+        (AL, C), A, C₀, alg::LeftCanonical;
+        timeroutput::TimerOutput = DISABLED_TIMER
+    )
     C[end] = normalize!(C₀)
     return LoggingExtras.withlevel(; alg.verbosity) do
         # initialize algorithm and temporary variables
         log = IterLog("LC")
         A_tail = _transpose_tail.(A) # pre-transpose A
         CA_tail = similar.(A_tail)  # pre-allocate workspace
-        state = (; AL, C, A, A_tail, CA_tail, iter = 0, ϵ = Inf)
+        state = (; AL, C, A, A_tail, CA_tail, iter = 0, ϵ = Inf, timeroutput)
         it = IterativeSolver(alg, state)
         loginit!(log, it.ϵ)
 
@@ -215,12 +230,15 @@ function uniform_leftorth!((AL, C), A, C₀, alg::LeftCanonical)
 end
 
 function Base.iterate(it::IterativeSolver{LeftCanonical}, state = it.state)
-    C₀ = gauge_eigsolve_step!(it, state)
-    C₁ = gauge_orth_step!(it, state)
+    timeroutput = state.timeroutput
+    C₀ = @timeit timeroutput "gauge_eigsolve" gauge_eigsolve_step!(it, state)
+    C₁ = @timeit timeroutput "gauge_orth" gauge_orth_step!(it, state)
     ϵ = oftype(state.ϵ, norm(C₀ - C₁))
 
     iter = state.iter + 1
-    it.state = (; state.AL, state.C, state.A, state.A_tail, state.CA_tail, iter, ϵ)
+    it.state = (;
+        state.AL, state.C, state.A, state.A_tail, state.CA_tail, iter, ϵ, timeroutput,
+    )
 
     return (it.state.AL, it.state.C), it.state
 end
@@ -247,13 +265,16 @@ function gauge_orth_step!(it::IterativeSolver{LeftCanonical}, state)
     return C[end]
 end
 
-function uniform_rightorth!((AR, C), A, C₀, alg::RightCanonical)
+function uniform_rightorth!(
+        (AR, C), A, C₀, alg::RightCanonical;
+        timeroutput::TimerOutput = DISABLED_TIMER
+    )
     C[end] = normalize!(C₀)
     return LoggingExtras.withlevel(; alg.verbosity) do
         # initialize algorithm and temporary variables
         log = IterLog("RC")
         AC_tail = _similar_tail.(A) # pre-allocate workspace
-        state = (; AR, C, A, AC_tail, iter = 0, ϵ = Inf)
+        state = (; AR, C, A, AC_tail, iter = 0, ϵ = Inf, timeroutput)
         it = IterativeSolver(alg, state)
         loginit!(log, it.ϵ)
 
@@ -273,12 +294,13 @@ function uniform_rightorth!((AR, C), A, C₀, alg::RightCanonical)
 end
 
 function Base.iterate(it::IterativeSolver{RightCanonical}, state = it.state)
-    C₀ = gauge_eigsolve_step!(it, state)
-    C₁ = gauge_orth_step!(it, state)
+    timeroutput = state.timeroutput
+    C₀ = @timeit timeroutput "gauge_eigsolve" gauge_eigsolve_step!(it, state)
+    C₁ = @timeit timeroutput "gauge_orth" gauge_orth_step!(it, state)
     ϵ = oftype(state.ϵ, norm(C₀ - C₁))
 
     iter = state.iter + 1
-    it.state = (; state.AR, state.C, state.A, state.AC_tail, iter, ϵ)
+    it.state = (; state.AR, state.C, state.A, state.AC_tail, iter, ϵ, timeroutput)
 
     return (it.state.AR, it.state.C), it.state
 end


### PR DESCRIPTION
This adds optional per-section timing to VUMPS, DMRG / DMRG2, IDMRG / IDMRG2, and GradientGrassmann, using TimerOutputs.jl. Each algorithm allocates its own `TimerOutput`, sub-sections mirror the natural phases (eigsolves, orth steps, env transfers, gauge solver, ...), and the summary is emitted via `@infov 4` so it is gated by the existing verbosity setting.

The section structures end up looking like:

```
VUMPS                        IDMRG / IDMRG2                 DMRG / DMRG2                 GradientGrassmann
├── localupdate              ├── localupdate                ├── sweep                    ├── fg
│   ├── AC_eigsolve          │   ├── AC_eigsolve  /         │   ├── AC_eigsolve  /       │   ├── envs
│   └── C_eigsolve           │   │   AC2_eigsolve           │   │   AC2_eigsolve         │   │   ├── left_envs
├── gauge                    │   ├── ortho_step /           │   ├── svd_trunc (DMRG2)    │   │   └── right_envs
│   ├── gauge_eigsolve       │   │   svd_trunc              │   └── AC_update            │   ├── expval
│   └── gauge_orth           │   └── transfer_env           └── finalize                 │   └── gradient
├── envs                                                                                  ├── retract
│   ├── left_envs                                                                         ├── transport!
│   └── right_envs                                                                        └── precondition
├── finalize
└── calc_galerkin
```

A representative VUMPS run with `verbosity=4` on a 3-site Ising chain:

```
Section            ncalls     time    %tot     avg     alloc    %tot      avg
─────────────────────────────────────────────────────────────────────────────
localupdate             6    262ms   64.8%  43.7ms   44.4MiB   46.1%  7.39MiB
  AC_eigsolve          18    271ms   67.0%  15.0ms   78.7MiB   81.7%  4.37MiB
  C_eigsolve           18    147ms   36.4%  8.17ms   35.0MiB   36.4%  1.95MiB
envs                    6   72.9ms   18.1%  12.2ms   33.7MiB   35.0%  5.62MiB
  left_envs             6   71.6ms   17.7%  11.9ms   33.6MiB   34.9%  5.60MiB
  right_envs            6   57.5ms   14.2%  9.58ms   29.5MiB   30.6%  4.92MiB
gauge                   6   62.3ms   15.4%  10.4ms   15.4MiB   16.0%  2.57MiB
  gauge_eigsolve       73   33.1ms    8.2%   453μs   9.39MiB    9.8%   132KiB
  gauge_orth           73   27.5ms    6.8%   377μs   5.60MiB    5.8%  78.5KiB
calc_galerkin           6   6.90ms    1.7%  1.15ms   2.78MiB    2.9%   474KiB
finalize                6    730ns    0.0%   122ns     0.00B    0.0%    0.00B
```

Note that inner sections can show `%tot > 100%` relative to their parent (`AC_eigsolve`'s 67% vs `localupdate`'s 64.8%) — that's because `tforeach` runs sites concurrently, so per-call wall-time summed across threads exceeds the parent's wall-clock.

Control is via the existing `verbosity`:

```julia
find_groundstate(ψ, H, VUMPS(; verbosity = 4))   # timer enabled and printed (= VERBOSE_ALL)
find_groundstate(ψ, H, VUMPS(; verbosity = 3))   # default — disable_timer! makes @timeit a no-op
```

Wherever a timed section sits inside a `tforeach` / `@spawn` (VUMPS site loop, env compute, multiline rows), each task gets its own `TimerOutput` and we `merge!` after the synchronization point. The merge target is computed dynamically from `timeroutput.timer_stack`, so nested wrappers like `fg → envs → left_envs` work without hardcoding tree paths.
