### PR TITLE
Fix: `FiniteExcited` excitations should return sorted by energies

### DIFF
--- a/src/algorithms/excitation/dmrgexcitation.jl
+++ b/src/algorithms/excitation/dmrgexcitation.jl
@@ -4,7 +4,7 @@ $(TYPEDEF)
 Variational optimization algorithm for excitations of finite MPS by minimizing the energy of
 
 ```math
-H - λᵢ |ψᵢ⟩⟨ψᵢ|
+H + λᵢ |ψᵢ⟩⟨ψᵢ|
 ```
 
 ## Fields

--- a/src/algorithms/excitation/dmrgexcitation.jl
+++ b/src/algorithms/excitation/dmrgexcitation.jl
@@ -37,8 +37,8 @@ function excitations(
     nstates = (states..., ne)
     ens, excis = excitations(H, alg, nstates; init = init, num = num - 1)
 
-    push!(ens, expectation_value(ne, H))
-    push!(excis, ne)
+    pushfirst!(ens, expectation_value(ne, H))
+    pushfirst!(excis, ne)
 
     return ens, excis
 end

--- a/test/algorithms/excitations.jl
+++ b/test/algorithms/excitations.jl
@@ -74,8 +74,9 @@ verbosity_conv = 1
                     DMRG(; verbosity, tol = 1.0e-6),
                     DMRG2(; verbosity, tol = 1.0e-6, trscheme = trunctol(; atol = 1.0e-4)),
                 )
-                energies_dm, _ = @testinferred excitations(H, FiniteExcited(; gsalg), ψ)
+                energies_dm, _ = @testinferred excitations(H, FiniteExcited(; gsalg), ψ; num = 3)
                 @test energies_dm[1] ≈ energies_QP[1] + expectation_value(ψ, H, envs) atol = 1.0e-4
+                @test issorted(real.(energies_dm))
             end
 
             # find energy with Chepiga ansatz


### PR DESCRIPTION
Fixes #441. 