### PR TITLE
fix: Periodic boundary conditions space mismatch for non-self-dual spaces

### DIFF
--- a/src/algorithms/toolbox.jl
+++ b/src/algorithms/toolbox.jl
@@ -176,8 +176,8 @@ function periodic_boundary_conditions(mpo::InfiniteMPO{O}, L = length(mpo)) wher
     local F_right
     for i in 1:L
         # kept as rightunitspace, but might need to change if we consider off-diagonal MPOs
-        V_left = i == 1 ? rightunitspace(V_wrap) : fuse(V_wrap ⊗ left_virtualspace(mpo, i))
-        V_right = i == L ? rightunitspace(V_wrap) : fuse(V_wrap ⊗ right_virtualspace(mpo, i))
+        V_left = i == 1 ? rightunitspace(V_wrap) : fuse(V_wrap' ⊗ left_virtualspace(mpo, i))
+        V_right = i == L ? rightunitspace(V_wrap) : fuse(V_wrap' ⊗ right_virtualspace(mpo, i))
         output[i] = similar(
             mpo[i], V_left * physicalspace(mpo, i) ← physicalspace(mpo, i) * V_right
         )

--- a/test/algorithms/periodic_boundary.jl
+++ b/test/algorithms/periodic_boundary.jl
@@ -20,6 +20,16 @@ using TensorKit: ℙ
         end
     end
 
+    # non-self-dual virtual space
+    let V = U1Space(0 => 1, 1 => 1), P = U1Space(0 => 1, 1 => 1)
+        mpo = InfiniteMPO([randn(ComplexF64, V ⊗ P ← P ⊗ V)])
+        for N in 2:4
+            TH = convert(TensorMap, periodic_boundary_conditions(mpo, N))
+            @test TH ≈
+                permute(TH, ((vcat(N, 1:(N - 1))...,), (vcat(2N, (N + 1):(2N - 1))...,)))
+        end
+    end
+
     # fermionic tests
     h = f_plus_f_min(Float64, Trivial) + f_min_f_plus(Float64, Trivial)
     H = InfiniteMPOHamiltonian([space(h, 1)], (1, 2) => h)

--- a/test/algorithms/periodic_boundary.jl
+++ b/test/algorithms/periodic_boundary.jl
@@ -31,7 +31,7 @@ using TensorKit: ℙ
     end
 
     # fermionic tests
-    h = f_plus_f_min(Float64, Trivial) + f_min_f_plus(Float64, Trivial)
+    h = f_hopping(Float64, Trivial)
     H = InfiniteMPOHamiltonian([space(h, 1)], (1, 2) => h)
     for N in 3:5
         H_periodic = periodic_boundary_conditions(H, N)

--- a/test/setup/testsetup.jl
+++ b/test/setup/testsetup.jl
@@ -11,16 +11,15 @@ using BlockTensorKit
 using LinearAlgebra: Diagonal
 using Combinatorics: permutations
 using TensorKitTensors.SpinOperators: S_x, S_y, S_z, S_x_S_x, S_y_S_y, S_z_S_z, S_exchange, S_plus_S_min, S_min_S_plus
-using TensorKitTensors.FermionOperators: f_plus_f_min, f_min_f_plus, f_plus_f_plus, f_min_f_min, f_num
+using TensorKitTensors.FermionOperators: f_plus_f_min, f_min_f_plus, f_plus_f_plus, f_min_f_min, f_num, f_hopping
 
 # exports
 export S_x, S_y, S_z
 export S_x_S_x, S_y_S_y, S_z_S_z
-export f_plus_f_min, f_min_f_plus, f_num
+export f_plus_f_min, f_min_f_plus, f_num, f_hopping
 export force_planar
 export symm_mul_mpo
-export transverse_field_ising, heisenberg_XXX, bilinear_biquadratic_model, XY_model,
-    kitaev_model
+export transverse_field_ising, heisenberg_XXX, bilinear_biquadratic_model, XY_model, kitaev_model
 export classical_ising_tensors, classical_ising, sixvertex
 
 # using TensorOperations
@@ -154,9 +153,9 @@ function kitaev_model(
         T::Type{<:Number} = ComplexF64, sym::Type{<:Sector} = Trivial;
         t = 1.0, mu = 1.0, Delta = 1.0, L = Inf
     )
-    TB = scale!(f_plus_f_min(T, sym) + f_min_f_plus(T, sym), -t / 2)     # tight-binding term
-    SC = scale!(f_plus_f_plus(T, sym) + f_min_f_min(T, sym), Delta / 2)  # superconducting term
-    CP = scale!(f_num(T, sym), -mu)                       # chemical potential term
+    TB = scale!(f_hopping(T, sym), -t / 2)                               # tight-binding term
+    SC = scale!(f_min_f_min(T, sym) - f_plus_f_plus(T, sym), Delta / 2)  # superconducting term
+    CP = scale!(f_num(T, sym), -mu)                                      # chemical potential term
 
     if L == Inf
         lattice = PeriodicArray([space(TB, 1)])
@@ -165,7 +164,7 @@ function kitaev_model(
         lattice = fill(space(TB, 1), L)
         onsite_terms = ((i,) => CP for i in 1:L)
         twosite_terms = ((i, i + 1) => TB + SC for i in 1:(L - 1))
-        terms = Iterators.flatten(twosite_terms, onsite_terms)
+        terms = Iterators.flatten((twosite_terms, onsite_terms))
         return FiniteMPOHamiltonian(lattice, terms)
     end
 end


### PR DESCRIPTION
As brought up by @minalouschleith, non-self-dual spaces had a mistake in the fused spaces which led to space mismatches.

Also found a small mistake in the kitaev model test version that should now be fixed.