### PR TITLE
Guard CBE bond expansion against zero-content bonds

### DIFF
--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -48,10 +48,9 @@ function changebonds(
         VL = left_null(ψ.AL[i])
         VR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
         intermediate = adjoint(VL) * AC2 * adjoint(VR)
-        # only normalize when there is expansion content: `normalize!` of a zero tensor produces
-        # NaNs that crash the SVD (see the finite `changebond!` methods below).
         nrm = norm(intermediate)
-        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && normalize!(intermediate)
+        # skip empty-content bonds; normalizing zero would NaN the SVD
+        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && scale!(intermediate, inv(nrm))
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
         AL′[i] = VL * U
@@ -77,9 +76,8 @@ function changebonds(ψ::MultilineMPS, H, alg::OptimalExpand, envs = environment
         VL = left_null(ψ.AL[i, j])
         VR = right_null!(_transpose_tail(ψ.AR[i, j + 1]; copy = true))
         intermediate = adjoint(VL) * AC2 * adjoint(VR)
-        # only normalize when there is expansion content (see the single-line variant above).
         nrm = norm(intermediate)
-        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && normalize!(intermediate)
+        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && scale!(intermediate, inv(nrm))
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
         AL′[i, j] = VL * U
@@ -106,11 +104,10 @@ function changebond!(site::Int, ::Val{:right}, ψ::AbstractFiniteMPS, H, alg::Op
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * AC2 * adjoint(NR)
-    # no expansion content at this bond (e.g. a product-state region, or a symmetry sector the
-    # Hamiltonian does not couple into yet): `normalize!` of a zero tensor would produce NaNs and
-    # crash the SVD, so leave the state untouched here instead.
-    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
-    _, _, Vᴴ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
+    nrm = norm(g2)
+    # nothing to expand here; normalizing a zero g2 would NaN the SVD
+    nrm ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
+    _, _, Vᴴ = svd_trunc!(scale!(g2, inv(nrm)); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site+1
     ar_re = Vᴴ * NR
@@ -137,9 +134,9 @@ function changebond!(site::Int, ::Val{:left}, ψ::AbstractFiniteMPS, H, alg::Opt
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * AC2 * adjoint(NR)
-    # no expansion content at this bond: skip (see the `:right` method for the rationale).
-    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
-    U, _, _ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
+    nrm = norm(g2)
+    nrm ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
+    U, _, _ = svd_trunc!(scale!(g2, inv(nrm)); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site-1
     Q = NL * U

--- a/src/algorithms/changebonds/optimalexpand.jl
+++ b/src/algorithms/changebonds/optimalexpand.jl
@@ -47,7 +47,11 @@ function changebonds(
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = left_null(ψ.AL[i])
         VR = right_null!(_transpose_tail(ψ.AR[i + 1]; copy = true))
-        intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
+        intermediate = adjoint(VL) * AC2 * adjoint(VR)
+        # only normalize when there is expansion content: `normalize!` of a zero tensor produces
+        # NaNs that crash the SVD (see the finite `changebond!` methods below).
+        nrm = norm(intermediate)
+        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && normalize!(intermediate)
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
         AL′[i] = VL * U
@@ -72,7 +76,10 @@ function changebonds(ψ::MultilineMPS, H, alg::OptimalExpand, envs = environment
         # Use the nullspaces and SVD decomposition to determine the optimal expansion space
         VL = left_null(ψ.AL[i, j])
         VR = right_null!(_transpose_tail(ψ.AR[i, j + 1]; copy = true))
-        intermediate = normalize!(adjoint(VL) * AC2 * adjoint(VR))
+        intermediate = adjoint(VL) * AC2 * adjoint(VR)
+        # only normalize when there is expansion content (see the single-line variant above).
+        nrm = norm(intermediate)
+        nrm > eps(real(scalartype(intermediate)))^(3 / 4) && normalize!(intermediate)
         U, _, Vᴴ = svd_trunc!(intermediate; trunc = alg.trscheme, alg = alg.alg_svd)
 
         AL′[i, j] = VL * U
@@ -99,6 +106,10 @@ function changebond!(site::Int, ::Val{:right}, ψ::AbstractFiniteMPS, H, alg::Op
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * AC2 * adjoint(NR)
+    # no expansion content at this bond (e.g. a product-state region, or a symmetry sector the
+    # Hamiltonian does not couple into yet): `normalize!` of a zero tensor would produce NaNs and
+    # crash the SVD, so leave the state untouched here instead.
+    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
     _, _, Vᴴ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site+1
@@ -126,6 +137,8 @@ function changebond!(site::Int, ::Val{:left}, ψ::AbstractFiniteMPS, H, alg::Opt
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * AC2 * adjoint(NR)
+    # no expansion content at this bond: skip (see the `:right` method for the rationale).
+    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
     U, _, _ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site-1

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -89,10 +89,10 @@ function changebond!(site::Int, ::Val{:right}, ψ::AbstractFiniteMPS, H, alg::Ra
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * ac2 * adjoint(NR)
-    # no expansion content at this bond: `normalize!` of a zero tensor would produce NaNs and
-    # crash the SVD, so leave the state untouched here instead.
-    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
-    _, _, Vᴴ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
+    nrm = norm(g2)
+    # nothing to expand here; normalizing a zero g2 would NaN the SVD
+    nrm ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
+    _, _, Vᴴ = svd_trunc!(scale!(g2, inv(nrm)); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site+1, zero weight at site
     ar_re = Vᴴ * NR
@@ -118,9 +118,9 @@ function changebond!(site::Int, ::Val{:left}, ψ::AbstractFiniteMPS, H, alg::Ran
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * ac2 * adjoint(NR)
-    # no expansion content at this bond: skip (see the `:right` method for the rationale).
-    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
-    U, _, _ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
+    nrm = norm(g2)
+    nrm ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
+    U, _, _ = svd_trunc!(scale!(g2, inv(nrm)); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site-1, zero weight at site
     Q = NL * U

--- a/src/algorithms/changebonds/randexpand.jl
+++ b/src/algorithms/changebonds/randexpand.jl
@@ -89,6 +89,9 @@ function changebond!(site::Int, ::Val{:right}, ψ::AbstractFiniteMPS, H, alg::Ra
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * ac2 * adjoint(NR)
+    # no expansion content at this bond: `normalize!` of a zero tensor would produce NaNs and
+    # crash the SVD, so leave the state untouched here instead.
+    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
     _, _, Vᴴ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site+1, zero weight at site
@@ -115,6 +118,8 @@ function changebond!(site::Int, ::Val{:left}, ψ::AbstractFiniteMPS, H, alg::Ran
 
     # select the dominant directions in the complement of the current state
     g2 = adjoint(NL) * ac2 * adjoint(NR)
+    # no expansion content at this bond: skip (see the `:right` method for the rationale).
+    norm(g2) ≤ eps(real(scalartype(g2)))^(3 / 4) && return ψ
     U, _, _ = svd_trunc!(normalize!(g2); trunc = alg.trscheme, alg = alg.alg_svd)
 
     # optimal vectors at site-1, zero weight at site

--- a/test/algorithms/changebonds.jl
+++ b/test/algorithms/changebonds.jl
@@ -96,6 +96,32 @@ end
     @test dim(left_virtualspace(state_tr, 5)) < dim(left_virtualspace(state_oe, 5))
 end
 
+# Regression: CBE expanders must not crash on bonds with no expansion content. A charged
+# single-particle fermionic (fℤ₂-graded) state carries only one parity sector on the bonds away
+# from the particle, so the projected two-site update `adjoint(NL) * AC2 * adjoint(NR)` is
+# *structurally exactly zero* there. `OptimalExpand`/`RandExpand` used to `normalize!` that zero
+# tensor, producing NaNs that crashed the SVD (`ArgumentError: invalid argument #4 to LAPACK
+# call`); they must instead skip such bonds, leaving the state unchanged.
+@testset "CBE zero-content bonds (graded)" begin
+    L = 6
+    H = kitaev_model(ComplexF64, Trivial; t = 1.0, mu = 0, Delta = 0, L = L)
+    P = physicalspace(H)[1]
+    S = typeof(P)
+    Vtriv = oneunit(P)
+    Vodd = S(c => dim(P, c) for c in sectors(P) if !isone(c))
+    # single particle created on the last site: interior bonds carry only the even sector, so
+    # the expansion content on them is exactly zero
+    state = FiniteMPS(
+        [isometry(ComplexF64, (k <= L ? Vtriv : Vodd) ⊗ P, (k < L ? Vtriv : Vodd)) for k in 1:L]
+    )
+
+    state_oe, _ = changebonds(state, H, OptimalExpand(; trscheme = truncrank(2)))
+    @test abs(dot(state, state_oe)) ≈ 1 atol = 1.0e-8
+
+    state_re = changebonds(state, RandExpand(; trscheme = truncrank(2)))
+    @test abs(dot(state, state_re)) ≈ 1 atol = 1.0e-8
+end
+
 # density-matrix-style MPS: each site carries two physical legs (ket ⊗ bra). The operator-free
 # bond-change algorithms (`RandExpand` expansion, `SvdCut` truncation) must handle the extra
 # physical leg. Operator-based expanders (`OptimalExpand`/`SketchedExpand`) are not covered here


### PR DESCRIPTION
## Problem

`OptimalExpand` and `RandExpand` (`changebond!`, and the infinite/multiline `OptimalExpand` loops) form the two-site update projected onto the state's orthogonal complement and then call `svd_trunc!(normalize!(g2))`. When a bond has **no expansion content** — a product-state region, or a symmetry sector the Hamiltonian does not couple into yet — `g2` is *exactly* zero, so `normalize!` divides by a zero norm and manufactures `NaN`s. The subsequent SVD then throws:

```
ArgumentError: invalid argument #4 to LAPACK call
```

This is easy to hit with CBE on a low-entanglement or charged symmetric state. It surfaced in single-site CBE-TDVP (`TDVP(; alg_expand = OptimalExpand(...))`) on a charged fermionic (fℤ₂-graded) single-particle state: interior bonds there carry a single parity sector, so the projected update on them is *structurally* zero. (A merely small-but-nonzero `g2`, e.g. from a random dense state, does not trigger it — the norm must be exactly `0`, which is why only structured/graded states hit it.)

## Fix

Guard the zero-content case: when the projected update has (near-)zero norm there is nothing to expand at that bond, so skip it and leave the state untouched.

- Finite `changebond!` (`OptimalExpand`/`RandExpand`, both sweep directions): early-return when `norm(g2) ≤ eps^(3/4)`.
- Infinite / multiline `OptimalExpand` loops: normalize only when the norm is above threshold.

`SketchedExpand` already handled this — it has an upfront empty-complement guard and orthogonalizes with QR/`right_orth!` rather than `normalize!`-then-SVD — so it is unchanged.

The guard only adds an early return on an exactly-zero-norm condition, so it cannot affect the normal (nonzero) expansion path.

## Testing

- New regression test `test/algorithms/changebonds.jl` → "CBE zero-content bonds (graded)": a charged single-particle fℤ₂ state (interior bonds carry a single sector ⇒ structurally-zero expansion content) run through `OptimalExpand` and `RandExpand`; both must complete without crashing and preserve the state. This reproduces the crash on the unpatched code.
- Full `test/algorithms/changebonds.jl` suite is green (54/54).
- Verified end-to-end that `OptimalExpand` CBE-TDVP, which previously crashed on the charged fermionic state, now runs and matches `TDVP2`/`RandExpand`, while a full-rank sanity case confirms the guard does not suppress genuinely-needed expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)