### PR TITLE
Refactor MPSTensor construction to fix type piracy

### DIFF
--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -13,77 +13,22 @@ const MPSBondTensor{S} = AbstractTensorMap{T, S, 1, 1} where {T}
 const GenericMPSTensor{S, N} = AbstractTensorMap{T, S, N, 1} where {T} # some functions are also defined for "general mps tensors" (used in peps code)
 const MPSTensor{S} = GenericMPSTensor{S, 2} # the usual mps tensors on which we work
 
-"""
-    MPSTensor([f, eltype], d::Int, left_D::Int, [right_D]::Int])
-    MPSTensor([f, eltype], physicalspace::Union{S,CompositeSpace{S}}, 
-              left_virtualspace::S, [right_virtualspace]::S) where {S<:ElementarySpace}
-
-Construct an `MPSTensor` with given physical and virtual spaces.
-
-### Arguments
-- `f::Function=rand`: initializer function for tensor data
-- `eltype::Type{<:Number}=ComplexF64`: scalar type of tensors
-
-- `physicalspace::Union{S,CompositeSpace{S}}`: physical space
-- `left_virtualspace::S`: left virtual space
-- `right_virtualspace::S`: right virtual space, defaults to equal left
-
-- `d::Int`: physical dimension
-- `left_D::Int`: left virtual dimension
-- `right_D::Int`: right virtual dimension
-"""
-function MPSTensor(
-        ::UndefInitializer, T, P::Union{S, CompositeSpace{S}}, Vₗ::S, Vᵣ::S = Vₗ
-    ) where {S <: ElementarySpace}
-    TT = tensormaptype(S, 1 + (P isa S ? 1 : length(P)), 1, T)
-    return TT(undef, Vₗ ⊗ P ← Vᵣ)
+struct MPSMapSpace{S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}}
+    Vₗ::S
+    P::Sₚ
+    Vᵣ::S
 end
-function MPSTensor(
-        f, T, P::Union{S, CompositeSpace{S}}, Vₗ::S, Vᵣ::S = Vₗ
-    ) where {S <: ElementarySpace}
-    A = MPSTensor(undef, T, P, Vₗ, Vᵣ)
-    if f === rand
-        return rand!(A)
-    elseif f === randn
-        return randn!(A)
-    elseif f === zeros
-        return zeros!(A)
-    else
-        throw(ArgumentError("Unsupported initializer function: $f"))
+
+MPSMapSpace(Vₗ::S, P::Sₚ) where {S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}} =
+    MPSMapSpace(Vₗ, P, Vₗ)
+
+MPSMapSpace(d::Int, Dₗ::Int, Dᵣ::Int = Dₗ) = MPSMapSpace(ℂ^d, ℂ^Dₗ, ℂ^Dᵣ)
+
+for f in (:rand, :randn, :zeros)
+    @eval function Base.$f(::Type{T}, A::MPSMapSpace) where {T}
+        return $f(T, A.Vₗ ⊗ A.P ← A.Vᵣ)
     end
-end
-# TODO: reinstate function initializers?
-function MPSTensor(
-        P::Union{S, CompositeSpace{S}}, Vₗ::S, Vᵣ::S = Vₗ
-    ) where {S <: ElementarySpace}
-    return MPSTensor(rand, Defaults.eltype, P, Vₗ, Vᵣ)
-end
-
-"""
-    MPSTensor([f, eltype], d::Int, Dₗ::Int, [Dᵣ]::Int])
-
-Construct an `MPSTensor` with given physical and virtual dimensions.
-
-### Arguments
-- `f::Function=rand`: initializer function for tensor data
-- `eltype::Type{<:Number}=ComplexF64`: scalar type of tensors
-- `d::Int`: physical dimension
-- `Dₗ::Int`: left virtual dimension
-- `Dᵣ::Int`: right virtual dimension
-"""
-MPSTensor(f, T, d::Int, Dₗ::Int, Dᵣ::Int = Dₗ) = MPSTensor(f, T, ℂ^d, ℂ^Dₗ, ℂ^Dᵣ)
-MPSTensor(d::Int, Dₗ::Int; Dᵣ::Int = Dₗ) = MPSTensor(ℂ^d, ℂ^Dₗ, ℂ^Dᵣ)
-
-"""
-    MPSTensor(A::AbstractArray)
-
-Convert an array to an `MPSTensor`.
-"""
-function MPSTensor(A::AbstractArray{<:Number})
-    @assert ndims(A) > 2 "MPSTensor should have at least 3 dims, but has $ndims(A)"
-    sz = size(A)
-    V = foldl(⊗, ComplexSpace.(sz[1:(end - 1)])) ← ℂ^sz[end]
-    return TensorMap(A, V)
+    @eval Base.$f(A::MPSMapSpace) = $f(Defaults.eltype, A)
 end
 
 """

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -14,69 +14,6 @@ const GenericMPSTensor{S, N} = AbstractTensorMap{T, S, N, 1} where {T} # some fu
 const MPSTensor{S} = GenericMPSTensor{S, 2} # the usual mps tensors on which we work
 
 """
-    $(TYPEDEF)
-
-Helper type that stores the spaces of an `AbstractTensorMap` following the `GenericMPSTensor`
-leg convention `Vₗ ⊗ P ← Vᵣ`, i.e. left virtual space and physical space(s) in the codomain,
-right virtual space in the domain. Centralizing this convention here avoids having to define
-constructors directly on `MPSTensor`/`GenericMPSTensor` (which are aliases for
-`AbstractTensorMap` and thus not owned by this package).
-
-### Fields
-$(TYPEDFIELDS)
-"""
-struct MPSMapSpace{S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}}
-    "left virtual space"
-    Vₗ::S
-    "physical space; either a single `ElementarySpace` (one physical leg, as in `MPSTensor`) or a `CompositeSpace{S}` (several physical legs, as in `GenericMPSTensor`)"
-    P::Sₚ
-    "right virtual space"
-    Vᵣ::S
-end
-
-"""
-    MPSMapSpace(Vₗ::S, P::Sₚ)
-
-Construct an `MPSMapSpace` with `Vᵣ` defaulting to `Vₗ`.
-"""
-MPSMapSpace(Vₗ::S, P::Sₚ) where {S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}} =
-    MPSMapSpace(Vₗ, P, Vₗ)
-
-"""
-    MPSMapSpace(d::Int, Dₗ::Int, [Dᵣ]::Int)
-
-Construct an `MPSMapSpace` with given physical and virtual dimensions, using `ComplexSpace`
-(`ℂ`) for all three spaces. `Dᵣ` defaults to `Dₗ`.
-
-### Arguments
-- `d::Int`: physical dimension
-- `Dₗ::Int`: left virtual dimension
-- `Dᵣ::Int`: right virtual dimension, defaults to `Dₗ`
-"""
-MPSMapSpace(d::Int, Dₗ::Int, Dᵣ::Int = Dₗ) = MPSMapSpace(ℂ^d, ℂ^Dₗ, ℂ^Dᵣ)
-
-const _MPSMAPSPACE_FILL_DESCRIPTIONS = Dict(
-    :rand => "filled with uniformly distributed random entries",
-    :randn => "filled with normally distributed random entries",
-    :zeros => "filled with zeros",
-)
-
-for f in (:rand, :randn, :zeros)
-    fill_description = _MPSMAPSPACE_FILL_DESCRIPTIONS[f]
-    @eval begin
-        @doc """
-            $($f)([T::Type=Defaults.eltype], A::MPSMapSpace)
-
-        Construct a tensor with `eltype` `T` and spaces `A.Vₗ ⊗ A.P ← A.Vᵣ`, $($fill_description).
-        """
-        function Base.$f(::Type{T}, A::MPSMapSpace) where {T}
-            return $f(T, A.Vₗ ⊗ A.P ← A.Vᵣ)
-        end
-        Base.$f(A::MPSMapSpace) = $f(Defaults.eltype, A)
-    end
-end
-
-"""
     isfullrank(A::GenericMPSTensor; side=:both)
 
 Determine whether the given tensor is full rank, i.e. whether both the map from the left

--- a/src/states/abstractmps.jl
+++ b/src/states/abstractmps.jl
@@ -13,22 +13,67 @@ const MPSBondTensor{S} = AbstractTensorMap{T, S, 1, 1} where {T}
 const GenericMPSTensor{S, N} = AbstractTensorMap{T, S, N, 1} where {T} # some functions are also defined for "general mps tensors" (used in peps code)
 const MPSTensor{S} = GenericMPSTensor{S, 2} # the usual mps tensors on which we work
 
+"""
+    $(TYPEDEF)
+
+Helper type that stores the spaces of an `AbstractTensorMap` following the `GenericMPSTensor`
+leg convention `Vₗ ⊗ P ← Vᵣ`, i.e. left virtual space and physical space(s) in the codomain,
+right virtual space in the domain. Centralizing this convention here avoids having to define
+constructors directly on `MPSTensor`/`GenericMPSTensor` (which are aliases for
+`AbstractTensorMap` and thus not owned by this package).
+
+### Fields
+$(TYPEDFIELDS)
+"""
 struct MPSMapSpace{S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}}
+    "left virtual space"
     Vₗ::S
+    "physical space; either a single `ElementarySpace` (one physical leg, as in `MPSTensor`) or a `CompositeSpace{S}` (several physical legs, as in `GenericMPSTensor`)"
     P::Sₚ
+    "right virtual space"
     Vᵣ::S
 end
 
+"""
+    MPSMapSpace(Vₗ::S, P::Sₚ)
+
+Construct an `MPSMapSpace` with `Vᵣ` defaulting to `Vₗ`.
+"""
 MPSMapSpace(Vₗ::S, P::Sₚ) where {S <: ElementarySpace, Sₚ <: Union{S, CompositeSpace{S}}} =
     MPSMapSpace(Vₗ, P, Vₗ)
 
+"""
+    MPSMapSpace(d::Int, Dₗ::Int, [Dᵣ]::Int)
+
+Construct an `MPSMapSpace` with given physical and virtual dimensions, using `ComplexSpace`
+(`ℂ`) for all three spaces. `Dᵣ` defaults to `Dₗ`.
+
+### Arguments
+- `d::Int`: physical dimension
+- `Dₗ::Int`: left virtual dimension
+- `Dᵣ::Int`: right virtual dimension, defaults to `Dₗ`
+"""
 MPSMapSpace(d::Int, Dₗ::Int, Dᵣ::Int = Dₗ) = MPSMapSpace(ℂ^d, ℂ^Dₗ, ℂ^Dᵣ)
 
+const _MPSMAPSPACE_FILL_DESCRIPTIONS = Dict(
+    :rand => "filled with uniformly distributed random entries",
+    :randn => "filled with normally distributed random entries",
+    :zeros => "filled with zeros",
+)
+
 for f in (:rand, :randn, :zeros)
-    @eval function Base.$f(::Type{T}, A::MPSMapSpace) where {T}
-        return $f(T, A.Vₗ ⊗ A.P ← A.Vᵣ)
+    fill_description = _MPSMAPSPACE_FILL_DESCRIPTIONS[f]
+    @eval begin
+        @doc """
+            $($f)([T::Type=Defaults.eltype], A::MPSMapSpace)
+
+        Construct a tensor with `eltype` `T` and spaces `A.Vₗ ⊗ A.P ← A.Vᵣ`, $($fill_description).
+        """
+        function Base.$f(::Type{T}, A::MPSMapSpace) where {T}
+            return $f(T, A.Vₗ ⊗ A.P ← A.Vᵣ)
+        end
+        Base.$f(A::MPSMapSpace) = $f(Defaults.eltype, A)
     end
-    @eval Base.$f(A::MPSMapSpace) = $f(Defaults.eltype, A)
 end
 
 """

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -258,7 +258,7 @@ function FiniteMPS(
     end
 
     # construct MPS
-    tensors = @. f(elt, MPSMapSpace(Vspaces[1:(end - 1)], Pspaces, Vspaces[2:end]))
+    tensors = @. f(elt, Vspaces[1:(end - 1)] ⊗ Pspaces ← Vspaces[2:end])
     return FiniteMPS(tensors; normalize, overwrite = true)
 end
 function FiniteMPS(

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -258,7 +258,7 @@ function FiniteMPS(
     end
 
     # construct MPS
-    tensors = MPSTensor.(f, elt, Pspaces, Vspaces[1:(end - 1)], Vspaces[2:end])
+    tensors = @. f(elt, MPSMapSpace(Vspaces[1:(end - 1)], Pspaces, Vspaces[2:end]))
     return FiniteMPS(tensors; normalize, overwrite = true)
 end
 function FiniteMPS(

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -121,20 +121,20 @@ function InfiniteMPS(
         pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
-    return InfiniteMPS(MPSTensor.(rand, T, pspaces, circshift(Dspaces, 1), Dspaces); kwargs...)
+    return InfiniteMPS(@. rand(T, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces)); kwargs...)
 end
 function InfiniteMPS(
         pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
-    return InfiniteMPS(MPSTensor.(rand, ComplexF64, pspaces, circshift(Dspaces, 1), Dspaces); kwargs...)
+    return InfiniteMPS(@. rand(ComplexF64, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces)); kwargs...)
 end
 function InfiniteMPS(
         f, T::Type, pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
     return InfiniteMPS(
-        MPSTensor.(f, T, pspaces, circshift(Dspaces, 1), Dspaces);
+        @. f(T, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces));
         kwargs...
     )
 end

--- a/src/states/infinitemps.jl
+++ b/src/states/infinitemps.jl
@@ -121,20 +121,20 @@ function InfiniteMPS(
         pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
-    return InfiniteMPS(@. rand(T, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces)); kwargs...)
+    return InfiniteMPS(@. rand(T, $circshift(Dspaces, 1) ⊗ pspaces ← Dspaces); kwargs...)
 end
 function InfiniteMPS(
         pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
-    return InfiniteMPS(@. rand(ComplexF64, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces)); kwargs...)
+    return InfiniteMPS(@. rand(ComplexF64, $circshift(Dspaces, 1) ⊗ pspaces ← Dspaces); kwargs...)
 end
 function InfiniteMPS(
         f, T::Type, pspaces::AbstractVector{S}, Dspaces::AbstractVector{S};
         kwargs...
     ) where {S <: IndexSpace}
     return InfiniteMPS(
-        @. f(T, MPSMapSpace($circshift(Dspaces, 1), pspaces, Dspaces));
+        @. f(T, $circshift(Dspaces, 1) ⊗ pspaces ← Dspaces);
         kwargs...
     )
 end


### PR DESCRIPTION
Closes #471.

Not really my place to be doing bigger refactors yet (this is only my second PR, after my
DMRG3S implementation), but the discussion in #471 pointed pretty directly at a concrete fix,
so I wanted to give it a try rather than just patching `zeros!` → `zerovector!` and leaving
the type piracy in place.

## What this does

- Removes the old `MPSTensor(f, T, P, Vₗ, Vᵣ)` / `MPSTensor(::UndefInitializer, ...)` /
  `MPSTensor(d, Dₗ, Dᵣ)` constructors, rather than just fixing the `zeros!` call inside them.
  As @lkdvos noted, these were type piracy (`MPSTensor` is a `const` alias for
  `AbstractTensorMap`, not a type MPSKit owns), and the original issue was really just a
  symptom of that.
- Introduces a small `MPSMapSpace{S, Sₚ}` struct that holds `(Vₗ, P, Vᵣ)`, so the
  `Vₗ ⊗ P ← Vᵣ` leg convention lives in exactly one place instead of being repeated in every
  constructor/accessor.
- Extends `Base.rand`/`Base.randn`/`Base.zeros` for `MPSMapSpace`, giving essentially the
  `zeros(T, Vl * P, Vr)`-style interface you mentioned as a preferred option, e.g.:

  ```julia
  julia> zeros(Float64, MPSMapSpace(ℂ^10, ℂ^2, ℂ^10))
  ```

  These are added as genuine `Base.rand`/`Base.randn`/`Base.zeros` methods (not a new type
  alias constructor), so there's no piracy here — `MPSMapSpace` is a type this package owns.

## What this does *not* do

I left out a dedicated `mpstensor(...)` convenience function for now. `MPSTensor` was never
exported, and grepping both MPSKit (src, test, docs, examples) and PEPSKit.jl for
`MPSTensor(`/`MPSTensor.(` turns up zero call sites outside the old constructor definitions
themselves, so I don't think there's a hidden dependency on the old constructor shapes. Given
that, it felt safer to start minimal and let you decide whether a convenience wrapper on top
of `MPSMapSpace` is actually wanted, rather than guessing at a signature nobody's using yet.

Happy to add `mpstensor` (or rename `MPSMapSpace` to something else, if `Vl * P` composite
notation is what you'd rather standardize on) if that's preferred — this is very much open
to being redirected.