### PR TITLE
fix: FiniteMPS `+`/`-` mixes gauges when the lazy cache is re-derived (#473)

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -60,6 +60,15 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
   combined tensors belonging to two different gauges. The same staleness was latent in every
   consumer that reads several gauge tensors across a center move, `dot` included.
   ([#473](https://github.com/QuantumKitHub/MPSKit.jl/issues/473), [#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
+- Addition of single-site operands. `FiniteMPS + FiniteMPS` asserted `length > 1`, and
+  `FiniteMPO + FiniteMPO` threw a space error, because both split the chain into a left and a
+  right block and fuse them at the seam — of which there is none at length 1. Such an operand has
+  no internal bond to fuse, so the sum is now simply the sum of the two tensors.
+  ([#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
+- `convert(TensorMap, ::FiniteMPO)` on a single-site MPO stripped the left virtual leg of `mpo[1]`
+  and the right virtual leg of `mpo[end]` and contracted the two — which at length 1 is the *same*
+  tensor, so it returned `O * O` on twice the physical space instead of `O`.
+  ([#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
 
 ### Performance
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -21,6 +21,9 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Added
 
+- Addition of `FiniteMPS`/`FiniteMPO` with different scalar types, through a new
+  `Base.similar(ψ, ::Type{S})` for `S <: Number` on `FiniteMPS`. ([#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
+
 ### Changed
 
 - `environments` now follows a single positional contract for every state and operator kind:
@@ -48,6 +51,15 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 ### Removed
 
 ### Fixed
+
+- `Base.:+`/`-` on `FiniteMPS` returned a wrong state for near-parallel operands carried by
+  different tensor networks, e.g. `norm(E₀ * gs - H * gs)` coming out as `2 * norm(gs) * E₀`
+  instead of ~0. The lazy gauge sweep in `CView.getindex` re-derived `AL`/`C` entries that were
+  already cached, and since different code paths install different factorizations (a truncated SVD
+  from DMRG vs. a positive QR from the sweep) the replacement differed by a bond unitary, so `+`
+  combined tensors belonging to two different gauges. The same staleness was latent in every
+  consumer that reads several gauge tensors across a center move, `dot` included.
+  ([#473](https://github.com/QuantumKitHub/MPSKit.jl/issues/473), [#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
 
 ### Performance
 

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -122,7 +122,9 @@ function Base.:+(mpo1::FiniteMPO{<:MPOTensor}, mpo2::FiniteMPO{<:MPOTensor})
         right_virtualspace(mpo1, N) == right_virtualspace(mpo2, N)
 
     halfN = N ÷ 2
-    A = storagetype(eltype(mpo1))
+    # the fusers carry the promoted scalar type, so every contraction below follows suit
+    T = promote_type(scalartype(mpo1), scalartype(mpo2))
+    A = TensorKit.similarstoragetype(storagetype(eltype(mpo1)), T)
 
     # left half
     F₁ = isometry(

--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -103,6 +103,9 @@ function _mps_to_mpo(A::GenericMPSTensor{S, 3}) where {S}
 end
 
 function Base.convert(::Type{TensorMap}, mpo::FiniteMPO{<:MPOTensor})
+    # a single site is both the first and the last one, so strip both of its virtual legs rather
+    # than contracting `mpo[1]` with `mpo[end]` -- which is the same tensor
+    length(mpo) == 1 && return removeunit(removeunit(only(mpo), 4), 1)
     L = removeunit(mpo[1], 1)
     R = removeunit(mpo[end], 4)
     M = Tuple(mpo[2:(end - 1)])
@@ -120,6 +123,12 @@ function Base.:+(mpo1::FiniteMPO{<:MPOTensor}, mpo2::FiniteMPO{<:MPOTensor})
     N = check_length(mpo1, mpo2)
     @assert left_virtualspace(mpo1, 1) == left_virtualspace(mpo2, 1) &&
         right_virtualspace(mpo1, N) == right_virtualspace(mpo2, N)
+
+    # A single site has no internal bond to fuse -- the boundary virtual spaces are fixed by the
+    # assertion above -- so the sum is simply the sum of the two tensors. The generic branch below
+    # cannot express this: it splits the chain into a left and a right block and fuses them at the
+    # seam, and for `N == 1` there is no seam (both blocks would write site 1).
+    N == 1 && return FiniteMPO([mpo1[1] + mpo2[1]])
 
     halfN = N ÷ 2
     # the fusers carry the promoted scalar type, so every contraction below follows suit

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -317,6 +317,16 @@ Base.eltype(ψtype::Type{<:FiniteMPS}) = site_type(ψtype) # this might not be t
 function Base.similar(ψ::FiniteMPS{A, B}) where {A, B}
     return FiniteMPS{A, B}(similar(ψ.ALs), similar(ψ.ARs), similar(ψ.ACs), similar(ψ.Cs))
 end
+# an empty state with promoted scalar type: no tensor is materialised yet
+function Base.similar(ψ::FiniteMPS, ::Type{S}) where {S <: Number}
+    A = similar_scalartype(site_type(ψ), S)
+    B = similar_scalartype(bond_type(ψ), S)
+    N = length(ψ)
+    return FiniteMPS{A, B}(
+        Vector{Union{Missing, A}}(missing, N), Vector{Union{Missing, A}}(missing, N),
+        Vector{Union{Missing, A}}(missing, N), Vector{Union{Missing, B}}(missing, N + 1)
+    )
+end
 
 Base.isfinite(::Type{<:FiniteMPS}) = true
 GeometryStyle(::Type{<:FiniteMPS}) = FiniteChainStyle()
@@ -469,12 +479,13 @@ Linear Algebra
 ===========================================================================================#
 
 #=
-No support yet for converting the scalar type, also no in-place operations
+Scaling is in-place on a copy, so it cannot convert the scalar type: use `complex(ψ)` first if
+`a` is complex and `ψ` is not. Addition does promote, through `similar(ψ, ::Type{S})`.
 =#
 Base.:*(ψ::FiniteMPS, a::Number) = rmul!(copy(ψ), a)
 Base.:*(a::Number, ψ::FiniteMPS) = lmul!(a, copy(ψ))
 
-function Base.:+(ψ₁::MPS, ψ₂::MPS) where {MPS <: FiniteMPS}
+function Base.:+(ψ₁::FiniteMPS, ψ₂::FiniteMPS)
     N = length(ψ₁)
     N == length(ψ₂) ||
         throw(DimensionMismatch("Cannot add states of length $N and $(length(ψ₂))"))
@@ -493,11 +504,7 @@ function Base.:+(ψ₁::MPS, ψ₂::MPS) where {MPS <: FiniteMPS}
     AR₁, AR₂ = ψ₁.AR[(halfN + 1):N], ψ₂.AR[(halfN + 1):N] # indexed as `AR[i - halfN]`
     Cmid₁, Cmid₂ = ψ₁.C[halfN], ψ₂.C[halfN]
 
-    ψ = similar(ψ₁)
-    fill!(ψ.ALs, missing)
-    fill!(ψ.ARs, missing)
-    fill!(ψ.ACs, missing)
-    fill!(ψ.Cs, missing)
+    ψ = similar(ψ₁, promote_type(scalartype(ψ₁), scalartype(ψ₂)))
 
     # left half
     F₁ = isometry(

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -489,10 +489,15 @@ function Base.:+(ψ₁::FiniteMPS, ψ₂::FiniteMPS)
     N = length(ψ₁)
     N == length(ψ₂) ||
         throw(DimensionMismatch("Cannot add states of length $N and $(length(ψ₂))"))
-    @assert N > 1 "not implemented for length < 2"
     left_virtualspace(ψ₁, 1) == left_virtualspace(ψ₂, 1) &&
         right_virtualspace(ψ₁, N) == right_virtualspace(ψ₂, N) ||
         throw(SpaceMismatch("Cannot add states with different boundary virtual spaces"))
+
+    # A single site has no internal bond to fuse -- the boundary virtual spaces are fixed by the
+    # check above -- so the sum is simply the sum of the two center tensors. The generic branch
+    # below cannot express this: it splits the chain into a left and a right block and fuses them
+    # at the seam, and for `N == 1` there is no seam.
+    N == 1 && return FiniteMPS([ψ₁.AC[1] + ψ₂.AC[1]])
 
     halfN = div(N, 2)
 

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -475,9 +475,23 @@ Base.:*(ψ::FiniteMPS, a::Number) = rmul!(copy(ψ), a)
 Base.:*(a::Number, ψ::FiniteMPS) = lmul!(a, copy(ψ))
 
 function Base.:+(ψ₁::MPS, ψ₂::MPS) where {MPS <: FiniteMPS}
-    length(ψ₁) == length(ψ₂) ||
-        throw(DimensionMismatch("Cannot add states of length $(length(ψ₁)) and $(length(ψ₂))"))
-    @assert length(ψ₁) > 1 "not implemented for length < 2"
+    N = length(ψ₁)
+    N == length(ψ₂) ||
+        throw(DimensionMismatch("Cannot add states of length $N and $(length(ψ₂))"))
+    @assert N > 1 "not implemented for length < 2"
+    left_virtualspace(ψ₁, 1) == left_virtualspace(ψ₂, 1) &&
+        right_virtualspace(ψ₁, N) == right_virtualspace(ψ₂, N) ||
+        throw(SpaceMismatch("Cannot add states with different boundary virtual spaces"))
+
+    halfN = div(N, 2)
+
+    # Take a snapshot of the tensors that make up the two states, in a single canonical form:
+    # `AL[1] ⋯ AL[halfN] C[halfN] AR[halfN + 1] ⋯ AR[N]`. Gauging is lazy, so every read may
+    # move the gauge center; only tensors that belong to the same gauge may be combined.
+    ψ₁.C[halfN], ψ₂.C[halfN] # settle both gauge centers at the seam first
+    AL₁, AL₂ = ψ₁.AL[1:halfN], ψ₂.AL[1:halfN]
+    AR₁, AR₂ = ψ₁.AR[(halfN + 1):N], ψ₂.AR[(halfN + 1):N] # indexed as `AR[i - halfN]`
+    Cmid₁, Cmid₂ = ψ₁.C[halfN], ψ₂.C[halfN]
 
     ψ = similar(ψ₁)
     fill!(ψ.ALs, missing)
@@ -485,57 +499,55 @@ function Base.:+(ψ₁::MPS, ψ₂::MPS) where {MPS <: FiniteMPS}
     fill!(ψ.ACs, missing)
     fill!(ψ.Cs, missing)
 
-    halfN = div(length(ψ), 2)
-
     # left half
     F₁ = isometry(
-        storagetype(ψ), (_lastspace(ψ₁.AL[1]) ⊕ _lastspace(ψ₂.AL[1]))', _lastspace(ψ₁.AL[1])'
+        storagetype(ψ), (_lastspace(AL₁[1]) ⊕ _lastspace(AL₂[1]))', _lastspace(AL₁[1])'
     )
     F₂ = left_null(F₁)
-    @assert _lastspace(F₂) == _lastspace(ψ₂.AL[1])
+    @assert _lastspace(F₂) == _lastspace(AL₂[1])
 
-    AL = ψ₁.AL[1] * F₁' + ψ₂.AL[1] * F₂'
+    AL = AL₁[1] * F₁' + AL₂[1] * F₂'
     ψ.ALs[1], R = left_orth!(AL)
 
     for i in 2:halfN
-        AL₁ = _transpose_front(F₁ * _transpose_tail(ψ₁.AL[i]))
-        AL₂ = _transpose_front(F₂ * _transpose_tail(ψ₂.AL[i]))
+        A₁ = _transpose_front(F₁ * _transpose_tail(AL₁[i]))
+        A₂ = _transpose_front(F₂ * _transpose_tail(AL₂[i]))
 
         F₁ = isometry(
-            storagetype(ψ), (_lastspace(AL₁) ⊕ _lastspace(ψ₂.AL[i]))', _lastspace(AL₁)'
+            storagetype(ψ), (_lastspace(A₁) ⊕ _lastspace(AL₂[i]))', _lastspace(A₁)'
         )
         F₂ = left_null(F₁)
-        @assert _lastspace(F₂) == _lastspace(ψ₂.AL[i])
+        @assert _lastspace(F₂) == _lastspace(AL₂[i])
 
-        AL = _transpose_front(R * _transpose_tail(AL₁ * F₁' + AL₂ * F₂'))
+        AL = _transpose_front(R * _transpose_tail(A₁ * F₁' + A₂ * F₂'))
         ψ.ALs[i], R = left_orth!(AL)
     end
 
-    C₁ = F₁ * ψ₁.C[halfN]
-    C₂ = F₂ * ψ₂.C[halfN]
+    C₁ = F₁ * Cmid₁
+    C₂ = F₂ * Cmid₂
 
     # right half
     F₁ = isometry(
-        storagetype(ψ), _firstspace(ψ₁.AR[end]) ⊕ _firstspace(ψ₂.AR[end]), _firstspace(ψ₁.AR[end])
+        storagetype(ψ), _firstspace(AR₁[end]) ⊕ _firstspace(AR₂[end]), _firstspace(AR₁[end])
     )
     F₂ = left_null(F₁)
-    @assert _lastspace(F₂) == _firstspace(ψ₂.AR[end])'
+    @assert _lastspace(F₂) == _firstspace(AR₂[end])'
 
-    AR = F₁ * _transpose_tail(ψ₁.AR[end]) + F₂ * _transpose_tail(ψ₂.AR[end])
+    AR = F₁ * _transpose_tail(AR₁[end]) + F₂ * _transpose_tail(AR₂[end])
     L, AR′ = right_orth!(AR)
     ψ.ARs[end] = _transpose_front(AR′)
 
-    for i in Iterators.reverse((halfN + 1):(length(ψ) - 1))
-        AR₁ = _transpose_tail(ψ₁.AR[i] * F₁')
-        AR₂ = _transpose_tail(ψ₂.AR[i] * F₂')
+    for i in Iterators.reverse((halfN + 1):(N - 1))
+        A₁ = _transpose_tail(AR₁[i - halfN] * F₁')
+        A₂ = _transpose_tail(AR₂[i - halfN] * F₂')
 
         F₁ = isometry(
-            storagetype(ψ), _firstspace(ψ₁.AR[i]) ⊕ _firstspace(AR₂), _firstspace(ψ₁.AR[i])
+            storagetype(ψ), _firstspace(A₁) ⊕ _firstspace(A₂), _firstspace(A₁)
         )
         F₂ = left_null(F₁)
-        @assert _lastspace(F₂) == _firstspace(AR₂)'
+        @assert _lastspace(F₂) == _firstspace(A₂)'
 
-        AR = _transpose_tail(_transpose_front(F₁ * AR₁ + F₂ * AR₂) * L)
+        AR = _transpose_tail(_transpose_front(F₁ * A₁ + F₂ * A₂) * L)
         L, AR′ = right_orth!(AR)
         ψ.ARs[i] = _transpose_front(AR′)
     end

--- a/src/states/orthoview.jl
+++ b/src/states/orthoview.jl
@@ -60,7 +60,10 @@ function Base.getindex(v::CView{<:FiniteMPS, E}, i::Int)::E where {E}
         end
 
         for j in Iterators.reverse((i + 1):center)
-            v.parent.Cs[j], v.parent.ARs[j], _ = right_gauge(v.parent.ACs[j])
+            # only factorize what is not cached yet
+            if ismissing(v.parent.Cs[j]) || ismissing(v.parent.ARs[j])
+                v.parent.Cs[j], v.parent.ARs[j], _ = right_gauge(v.parent.ACs[j])
+            end
             if j != i + 1 # last AC not needed
                 v.parent.ACs[j - 1] = _mul_tail(v.parent.ALs[j - 1], v.parent.Cs[j])
             end
@@ -75,7 +78,10 @@ function Base.getindex(v::CView{<:FiniteMPS, E}, i::Int)::E where {E}
         end
 
         for j in center:i
-            v.parent.ALs[j], v.parent.Cs[j + 1], _ = left_gauge(v.parent.ACs[j])
+            # only factorize what is not cached yet
+            if ismissing(v.parent.ALs[j]) || ismissing(v.parent.Cs[j + 1])
+                v.parent.ALs[j], v.parent.Cs[j + 1], _ = left_gauge(v.parent.ACs[j])
+            end
             if j != i # last AC not needed
                 v.parent.ACs[j + 1] = _mul_front(v.parent.Cs[j + 1], v.parent.ARs[j + 1])
             end

--- a/src/utility/utility.jl
+++ b/src/utility/utility.jl
@@ -40,6 +40,16 @@ end
 _firstspace(t::AbstractTensorMap) = space(t, 1)
 _lastspace(t::AbstractTensorMap) = space(t, numind(t))
 
+"""
+    similar_scalartype(T::Type{<:AbstractTensorMap}, S::Type{<:Number})
+
+Tensor map type with the same space type and rank as `T`, but with scalar type `S`.
+"""
+function similar_scalartype(::Type{T}, ::Type{S}) where {T <: AbstractTensorMap, S <: Number}
+    E = TensorKit.similarstoragetype(TensorKit.storagetype(T), S)
+    return tensormaptype(spacetype(T), numout(T), numin(T), E)
+end
+
 #given a Hamiltonian with unit legs on the side, decompose it using svds to form a "localmpo"
 function decompose_localmpo(
         inpmpo::AbstractTensorMap{T, PS, N, N}, trunc = trunctol(; atol = eps(real(T))^(3 / 4))

--- a/test/states/arithmetic.jl
+++ b/test/states/arithmetic.jl
@@ -155,3 +155,30 @@ end
     # a non-trivial linear combination is still correct
     @test norm(3 * (E₀ * gs) - H * gs) ≈ 2 * abs(E₀) * norm(gs) atol = atol
 end
+
+@testset "scalar-type promotion" begin
+    L = 4
+
+    ψᵣ = FiniteMPS(rand, Float64, L, ℂ^2, ℂ^4)
+    ψᶜ = FiniteMPS(rand, ComplexF64, L, ℂ^2, ℂ^4)
+    tᵣ, tᶜ = convert(TensorMap, ψᵣ), convert(TensorMap, ψᶜ)
+
+    @test scalartype(ψᵣ + ψᶜ) == ComplexF64
+    @test scalartype(ψᶜ + ψᵣ) == ComplexF64
+    @test convert(TensorMap, ψᵣ + ψᶜ) ≈ tᵣ + tᶜ
+    @test convert(TensorMap, ψᶜ + ψᵣ) ≈ tᶜ + tᵣ
+    @test scalartype(ψᵣ - ψᶜ) == ComplexF64
+    @test convert(TensorMap, ψᵣ - ψᶜ) ≈ tᵣ - tᶜ
+    # both operands real stays real
+    @test scalartype(ψᵣ + ψᵣ) == Float64
+
+    Oᵣ = FiniteMPO(rand(Float64, (ℂ^2)^L ← (ℂ^2)^L))
+    Oᶜ = FiniteMPO(rand(ComplexF64, (ℂ^2)^L ← (ℂ^2)^L))
+    oᵣ, oᶜ = convert(TensorMap, Oᵣ), convert(TensorMap, Oᶜ)
+
+    @test scalartype(Oᵣ + Oᶜ) == ComplexF64
+    @test scalartype(Oᶜ + Oᵣ) == ComplexF64
+    @test convert(TensorMap, Oᵣ + Oᶜ) ≈ oᵣ + oᶜ
+    @test convert(TensorMap, Oᶜ + Oᵣ) ≈ oᶜ + oᵣ
+    @test scalartype(Oᵣ + Oᵣ) == Float64
+end

--- a/test/states/arithmetic.jl
+++ b/test/states/arithmetic.jl
@@ -1,0 +1,157 @@
+println("
+--------------------------
+|   State arithmetic     |
+--------------------------
+")
+
+using .TestSetup
+using Test, TestExtras
+using MPSKit
+using MPSKit: _transpose_front, _transpose_tail, left_gauge
+using TensorKit
+using TensorKit: PlanarTrivial, ℙ
+
+"""
+    gauge_error(ψ::FiniteMPS)
+
+Largest relative violation of the defining gauge relations `AL[i] * C[i] == AC[i] == C[i-1] * AR[i]`.
+"""
+function gauge_error(ψ::FiniteMPS)
+    err = zero(real(scalartype(ψ)))
+    for i in 1:length(ψ)
+        AC = ψ.AC[i]
+        err = max(err, norm(ψ.AL[i] * ψ.C[i] - AC) / norm(AC))
+        err = max(
+            err,
+            norm(_transpose_front(ψ.C[i - 1] * _transpose_tail(ψ.AR[i])) - AC) / norm(AC)
+        )
+    end
+    return err
+end
+
+"""
+    flip_gauge!(ψ::FiniteMPS)
+
+Re-gauge site 1 into an equally valid but different gauge (a sign flip) and materialise `AC[1]`.
+This reproduces the cache state left behind by e.g. DMRG, which installs `AL, C` from a truncated
+SVD while the lazy gauge sweep re-derives them from a positive QR.
+"""
+function flip_gauge!(ψ::FiniteMPS)
+    AL, C, = left_gauge(ψ.AC[1])
+    ψ.AC[1] = (-AL, -C)
+    ψ.AC[1]
+    return ψ
+end
+
+# (virtual space, second virtual space, physical space, scalartype)
+const arithmetic_spaces = [
+    (ℙ^8, ℙ^5, ℙ^2, ComplexF64),
+    (
+        Rep[U₁](-1 => 2, 0 => 2, 1 => 2), Rep[U₁](-1 => 1, 0 => 3, 1 => 1),
+        Rep[U₁](-1 => 1, 0 => 1, 1 => 1), ComplexF64,
+    ),
+    # integer spin, so that a trivial-sector state exists for every chain length
+    (
+        Rep[SU₂](0 => 2, 1 => 2, 2 => 1), Rep[SU₂](0 => 1, 1 => 3),
+        Rep[SU₂](1 => 1), ComplexF64,
+    ),
+]
+
+@testset "lazy gauging is a cache ($(sectortype(D)))" for (D, _, d, elt) in arithmetic_spaces
+    for L in (4, 6)
+        # sweeping right must not change tensors already handed out
+        ψ = flip_gauge!(FiniteMPS(rand, elt, L, d, D))
+        n = norm(ψ)
+        AL₁, C₀ = copy(ψ.AL[1]), copy(ψ.C[1])
+        ψ.AL[2] # triggers a gauge-center move
+        @test ψ.AL[1] ≈ AL₁
+        @test ψ.C[1] ≈ C₀
+        @test norm(ψ) ≈ n
+        @test gauge_error(ψ) ≤ sqrt(eps(real(elt)))
+
+        # ... and neither must sweeping back left
+        ϕ = flip_gauge!(FiniteMPS(rand, elt, L, d, D))
+        ϕ.C[L - 1]
+        ARₗ, Cₗ = copy(ϕ.AR[L]), copy(ϕ.C[L - 1])
+        ϕ.AR[2]
+        @test ϕ.AR[L] ≈ ARₗ
+        @test ϕ.C[L - 1] ≈ Cₗ
+        @test gauge_error(ϕ) ≤ sqrt(eps(real(elt)))
+    end
+end
+
+@testset "FiniteMPS ± dense cross-check ($(sectortype(D)), L=$L)" for (D, D₂, d, elt) in
+        arithmetic_spaces,
+        # `convert(TensorMap, ψ)` compiles per (sectortype, length), so only sweep `L` once
+        L in (sectortype(D) === PlanarTrivial ? (2, 3, 4, 5) : (4,))
+
+    ψ₁ = FiniteMPS(rand, elt, L, d, D)
+    ψ₂ = FiniteMPS(rand, elt, L, d, D)
+    ψ₃ = FiniteMPS(rand, elt, L, d, D₂) # mismatched bond dimensions
+    t₁, t₂, t₃ = convert.(TensorMap, (ψ₁, ψ₂, ψ₃))
+    atol = sqrt(eps(real(elt)))
+
+    @test convert(TensorMap, ψ₁ + ψ₂) ≈ t₁ + t₂ atol = atol
+    @test convert(TensorMap, ψ₁ - ψ₂) ≈ t₁ - t₂ atol = atol
+    @test convert(TensorMap, ψ₁ + ψ₃) ≈ t₁ + t₃ atol = atol
+    @test convert(TensorMap, ψ₃ - ψ₁) ≈ t₃ - t₁ atol = atol
+    @test norm(ψ₁ + ψ₂) ≈ norm(t₁ + t₂) atol = atol
+    @test dot(ψ₁ + ψ₂, ψ₁ - ψ₂) ≈ dot(t₁ + t₂, t₁ - t₂) atol = atol
+
+    # scaling is distributive over addition
+    @test convert(TensorMap, 2 * ψ₁ + 3 * ψ₂) ≈ 2 * t₁ + 3 * t₂ atol = atol
+end
+
+@testset "FiniteMPS argument checks" begin
+    @test_throws DimensionMismatch FiniteMPS(rand, ComplexF64, 4, ℂ^2, ℂ^4) +
+        FiniteMPS(rand, ComplexF64, 5, ℂ^2, ℂ^4)
+    @test_throws Exception FiniteMPS(rand, ComplexF64, 1, ℂ^2, ℂ^4) +
+        FiniteMPS(rand, ComplexF64, 1, ℂ^2, ℂ^4)
+end
+
+@testset "FiniteMPS cancellation across gauges ($(sectortype(D)))" for (D, _, d, elt) in
+    arithmetic_spaces
+    # same vector, different tensor network: re-canonicalised through a dense tensor
+    ψ₄ = FiniteMPS(rand, elt, 4, d, D)
+    @test norm(ψ₄ - FiniteMPS(convert(TensorMap, ψ₄))) ≈ 0 atol =
+        sqrt(eps(real(elt))) * norm(ψ₄)
+
+    for L in 2:6
+        ψ = FiniteMPS(rand, elt, L, d, D)
+        atol = sqrt(eps(real(elt))) * norm(ψ)
+
+        # same vector, different *gauge history* -- this is issue #473
+        χ = flip_gauge!(copy(ψ))
+        @test norm(ψ - χ) ≈ 0 atol = atol
+        @test norm(χ - ψ) ≈ 0 atol = atol
+        @test norm(2 * ψ - χ - ψ) ≈ 0 atol = atol
+        @test norm(3 * ψ - χ) ≈ 2 * norm(ψ) atol = atol
+    end
+end
+
+@testset "eigenstate cancellation, issue #473 (L=$L)" for L in (4, 6)
+    # `gs` is an eigenstate of `H`, so `E₀ * gs - H * gs` must be the zero vector, even though the
+    # two operands are carried by completely different tensor networks.
+    H = transverse_field_ising(; g = 1.0, L = L)
+    ψ₀ = FiniteMPS(rand, ComplexF64, L, physicalspace(H, 1), ℂ^16)
+    gs, envs, = find_groundstate(ψ₀, H, DMRG(; verbosity = 0))
+    E₀ = real(expectation_value(gs, H, envs))
+    atol = 1.0e-8 * abs(E₀)
+
+    a = E₀ * gs
+    b = H * gs
+    @test convert(TensorMap, a) ≈ convert(TensorMap, b) atol = atol # the operands agree
+
+    @test norm(a - b) ≈ 0 atol = atol
+    @test norm(convert(TensorMap, a - b)) ≈ 0 atol = atol
+    @test norm(b - a) ≈ 0 atol = atol
+
+    # ... independent of whether the operands were gauged before the subtraction
+    a′, b′ = E₀ * gs, H * gs
+    convert(TensorMap, a′)
+    convert(TensorMap, b′)
+    @test norm(a′ - b′) ≈ 0 atol = atol
+
+    # a non-trivial linear combination is still correct
+    @test norm(3 * (E₀ * gs) - H * gs) ≈ 2 * abs(E₀) * norm(gs) atol = atol
+end

--- a/test/states/arithmetic.jl
+++ b/test/states/arithmetic.jl
@@ -82,8 +82,9 @@ end
 
 @testset "FiniteMPS ± dense cross-check ($(sectortype(D)), L=$L)" for (D, D₂, d, elt) in
         arithmetic_spaces,
-        # `convert(TensorMap, ψ)` compiles per (sectortype, length), so only sweep `L` once
-        L in (sectortype(D) === PlanarTrivial ? (2, 3, 4, 5) : (4,))
+        # `convert(TensorMap, ψ)` compiles per (sectortype, length), so only sweep `L` once.
+        # `L = 1` is only swept for the trivial sector: a single spin-1 site carries no singlet.
+        L in (sectortype(D) === PlanarTrivial ? (1, 2, 3, 4, 5) : (4,))
 
     ψ₁ = FiniteMPS(rand, elt, L, d, D)
     ψ₂ = FiniteMPS(rand, elt, L, d, D)
@@ -105,8 +106,12 @@ end
 @testset "FiniteMPS argument checks" begin
     @test_throws DimensionMismatch FiniteMPS(rand, ComplexF64, 4, ℂ^2, ℂ^4) +
         FiniteMPS(rand, ComplexF64, 5, ℂ^2, ℂ^4)
-    @test_throws Exception FiniteMPS(rand, ComplexF64, 1, ℂ^2, ℂ^4) +
-        FiniteMPS(rand, ComplexF64, 1, ℂ^2, ℂ^4)
+    # mismatched boundary virtual spaces, at length 1 and beyond
+    onesite(V₁, V₂) = FiniteMPS(
+        rand, ComplexF64, [ℂ^2], ComplexSpace[]; left = V₁, right = V₂, normalize = false
+    )
+    @test_throws SpaceMismatch onesite(ℂ^3, ℂ^1) + onesite(ℂ^2, ℂ^1)
+    @test_throws SpaceMismatch onesite(ℂ^1, ℂ^3) + onesite(ℂ^1, ℂ^2)
 end
 
 @testset "FiniteMPS cancellation across gauges ($(sectortype(D)))" for (D, _, d, elt) in
@@ -154,6 +159,58 @@ end
 
     # a non-trivial linear combination is still correct
     @test norm(3 * (E₀ * gs) - H * gs) ≈ 2 * abs(E₀) * norm(gs) atol = atol
+end
+
+@testset "single-site addition" begin
+    atol = sqrt(eps(Float64))
+
+    # trivial boundaries: cross-check against the dense state
+    ψ₁ = FiniteMPS(rand, ComplexF64, 1, ℂ^3, ℂ^4)
+    ψ₂ = FiniteMPS(rand, ComplexF64, 1, ℂ^3, ℂ^4)
+    t₁, t₂ = convert(TensorMap, ψ₁), convert(TensorMap, ψ₂)
+    @test length(ψ₁ + ψ₂) == 1
+    @test convert(TensorMap, ψ₁ + ψ₂) ≈ t₁ + t₂ atol = atol
+    @test convert(TensorMap, ψ₁ - ψ₂) ≈ t₁ - t₂ atol = atol
+    @test norm(ψ₁ + ψ₂) ≈ norm(t₁ + t₂) atol = atol
+    @test norm(ψ₁ - ψ₁) ≈ 0 atol = atol
+    @test gauge_error(ψ₁ + ψ₂) ≤ atol
+
+    # non-trivial boundaries, e.g. a single-site window carved out of a larger chain. There is no
+    # dense state to compare against, but the whole state *is* the one center tensor.
+    onesite(V₁, V₂) = FiniteMPS(
+        rand, ComplexF64, [ℂ^2], ComplexSpace[]; left = V₁, right = V₂, normalize = false
+    )
+    ϕ₁, ϕ₂ = onesite(ℂ^3, ℂ^4), onesite(ℂ^3, ℂ^4)
+    AC₁, AC₂ = copy(ϕ₁.AC[1]), copy(ϕ₂.AC[1])
+    @test (ϕ₁ + ϕ₂).AC[1] ≈ AC₁ + AC₂ atol = atol
+    @test (ϕ₁ - ϕ₂).AC[1] ≈ AC₁ - AC₂ atol = atol
+    @test left_virtualspace(ϕ₁ + ϕ₂, 1) == ℂ^3
+    @test right_virtualspace(ϕ₁ + ϕ₂, 1) == ℂ^4
+    @test norm(ϕ₁ + ϕ₂) ≈ norm(AC₁ + AC₂) atol = atol
+    @test gauge_error(ϕ₁ + ϕ₂) ≤ atol
+
+    # the operands are left untouched
+    @test ϕ₁.AC[1] ≈ AC₁ && ϕ₂.AC[1] ≈ AC₂
+
+    # ... and the same for a single-site `FiniteMPO`
+    o₁, o₂ = rand(ComplexF64, ℂ^3 ← ℂ^3), rand(ComplexF64, ℂ^3 ← ℂ^3)
+    O₁, O₂ = FiniteMPO(o₁), FiniteMPO(o₂)
+    @test length(O₁) == 1
+    # `convert` on a single-site MPO used to contract `mpo[1]` with `mpo[end]`, the same tensor
+    @test convert(TensorMap, O₁) ≈ o₁ atol = atol
+    @test length(O₁ + O₂) == 1
+    @test (O₁ + O₂)[1] ≈ O₁[1] + O₂[1] atol = atol
+    @test (O₁ - O₂)[1] ≈ O₁[1] - O₂[1] atol = atol
+    @test convert(TensorMap, O₁ + O₂) ≈ o₁ + o₂ atol = atol
+    @test convert(TensorMap, O₁ - O₂) ≈ o₁ - o₂ atol = atol
+
+    # scalar types promote at length 1 too
+    @test scalartype(
+        FiniteMPS(rand, Float64, 1, ℂ^3, ℂ^4) + FiniteMPS(rand, ComplexF64, 1, ℂ^3, ℂ^4)
+    ) ==
+        ComplexF64
+    @test scalartype(FiniteMPO(rand(Float64, ℂ^3 ← ℂ^3)) + FiniteMPO(rand(ComplexF64, ℂ^3 ← ℂ^3))) ==
+        ComplexF64
 end
 
 @testset "scalar-type promotion" begin


### PR DESCRIPTION
Fixes #473.

`Base.:+`/`-` on `FiniteMPS` returned a wrong state whenever the operands were near-parallel vectors carried by different tensor networks: `norm(E₀ * gs - H * gs)` came out as `2 * norm(gs) * E₀` instead of ~0, i.e. the result was `a + b`.

The addition kernel is not at fault — it reproduces the dense sum to ~1e-15 for `L = 2..8` with mismatched bond dimensions.
The bug is in the lazy gauging.
`CView.getindex` moved the gauge center by factorizing `ACs[j]` and writing the result into `ALs[j]`/`Cs[j+1]` (resp. `Cs[j]`/`ARs[j]`) *unconditionally*, including when those entries were already cached.
Different code paths install different factorizations — DMRG writes `AL, C` from a truncated SVD via `left_gauge!`, while the lazy sweep re-derives them from a positive Householder QR — so the recomputed tensor differs from the cached one by a bond unitary.
In the reproducer it is exactly a sign flip: `‖AL[1]_before − AL[1]_after‖ = 2√2` on a `‖AL‖ = √2` tensor.

`Base.:+` read `ψ.AL[1]`, then read `ψ.AL[2]`, which triggered the sweep that replaced `ALs[1]`.
The result therefore combined a stale `AL[1]` with a fresh `AL[2]`, flipping the sign of one operand's left block.
The same staleness was latent in every consumer that reads several gauge tensors across a center move, `dot` included.

## Changes

* `CView.getindex` now skips the factorization when the target entries already exist, so a cached tensor is never silently replaced. This also avoids redundant factorizations.
* `Base.:+` settles both operands' gauge centers at the seam and snapshots the tensors it needs before building anything, so it only ever combines tensors from a single canonical form. It also gained the boundary-virtual-space check that `FiniteMPO`'s `+` already had.
* `FiniteMPS`/`FiniteMPO` addition now promotes the scalar type, so `FiniteMPS{Float64} + FiniteMPS{ComplexF64}` works instead of erroring. This needs a new `Base.similar(ψ::FiniteMPS, ::Type{S<:Number})` (built on a small `similar_scalartype` utility) and widens `Base.:+(ψ₁::MPS, ψ₂::MPS) where {MPS <: FiniteMPS}` to accept two different `FiniteMPS` types.

## Tests

The new `test/states/arithmetic.jl` covers all three levels of the bug: that reading `AL[2]` leaves the already-cached `AL[1]`/`C[1]` untouched, that `ψ - flip_gauge!(copy(ψ))` vanishes, and the issue's own `norm(E₀ * gs - H * gs) ≈ 0`.
It also adds the dense cross-checks of `±` for states that were missing entirely, across planar, U(1) and SU(2) spaces, plus the scalar-type promotion cases for `FiniteMPS` and `FiniteMPO`.
