### PR TITLE
fix: `remove_orphans!` fixed-point condition on infinite MPOs

### DIFF
--- a/src/operators/abstractmpo.jl
+++ b/src/operators/abstractmpo.jl
@@ -76,7 +76,7 @@ function remove_orphans!(mpo::SparseMPO; tol = eps(real(scalartype(mpo)))^(3 / 4
                     return j ∈ getindex.(nonzero_keys(mpo[i]), 4) &&
                         j ∈ getindex.(nonzero_keys(mpo[i + 1]), 1)
                 end
-                changed |= length(mask) == size(mpo[i], 4)
+                changed |= length(mask) != size(mpo[i], 4)
                 mpo[i] = mpo[i][:, :, :, mask]
                 mpo[i + 1] = mpo[i + 1][mask, :, :, :]
             end

--- a/test/operators/mpo.jl
+++ b/test/operators/mpo.jl
@@ -8,8 +8,11 @@ using .TestSetup
 using Test, TestExtras
 using MPSKit
 using MPSKit: GeometryStyle, FiniteChainStyle, InfiniteChainStyle, OperatorStyle, MPOStyle
+using MPSKit: remove_orphans!
 using TensorKit
 using TensorKit: ℙ
+using BlockTensorKit
+using BlockTensorKit: SparseBlockTensorMap, nonzero_keys
 using Adapt
 
 @testset "FiniteMPO" begin
@@ -110,6 +113,71 @@ end
     @test right_virtualspace(multiH, CartesianIndex(1, 2)) == V
     @test leftunit(multiH) == leftunit(H) == unit(sectortype(P))
     @test rightunit(multiH) == rightunit(H) == unit(sectortype(P))
+end
+
+@testset "remove_orphans!" begin
+    T = ComplexF64
+    P = ℂ^2
+    TT = tensormaptype(ComplexSpace, 2, 2, Vector{T})
+    randmpotensor() = rand(T, ℂ^1 ⊗ P ← P ⊗ ℂ^1)
+
+    @testset "infinite: dead-end chain" begin
+        # 1 -> 1, 1 -> 2 -> 3 -> 4, where channel 4 is a dead end: removing it orphans 3,
+        # removing 3 orphans 2, ... so the fixed point takes several passes to reach
+        V = SumSpace(fill(ℂ^1, 4)...)
+        W = SparseBlockTensorMap{TT}(undef, V ⊗ P ← P ⊗ V)
+        for (i, j) in ((1, 1), (1, 2), (2, 3), (3, 4))
+            W[i, 1, 1, j] = randmpotensor()
+        end
+        W₁₁ = copy(W[1, 1, 1, 1])
+
+        mpo = InfiniteMPO([W])
+        @test !isfinite(mpo)
+        @test remove_orphans!(mpo) === mpo
+
+        # only the (1, 1) self-loop survives
+        @test left_virtualspace(mpo, 1) == right_virtualspace(mpo, 1) == SumSpace(ℂ^1)
+        @test collect(nonzero_keys(mpo[1])) == [CartesianIndex(1, 1, 1, 1)]
+        @test mpo[1][1, 1, 1, 1] ≈ W₁₁
+    end
+
+    @testset "infinite: nothing to remove" begin
+        # every channel is alive, so this must terminate immediately and change nothing
+        H = transverse_field_ising(T; g = 0.7)
+        mpo = MPO(map(SparseBlockTensorMap, parent(H)))
+        @test !isfinite(mpo)
+
+        spaces₀ = map(space, parent(mpo))
+        keys₀ = map(W -> sort!(collect(nonzero_keys(W))), parent(mpo))
+        remove_orphans!(mpo)
+        @test map(space, parent(mpo)) == spaces₀
+        @test map(W -> sort!(collect(nonzero_keys(W))), parent(mpo)) == keys₀
+    end
+
+    @testset "finite: dead-end chain" begin
+        # channel 2 is never entered on site 1, so the (2, 2) block on site 2 and the
+        # (2, 1) block on site 3 are orphaned
+        V₁ = SumSpace(ℂ^1)
+        V₂ = SumSpace(ℂ^1, ℂ^1)
+        Ws = [
+            SparseBlockTensorMap{TT}(undef, V₁ ⊗ P ← P ⊗ V₂),
+            SparseBlockTensorMap{TT}(undef, V₂ ⊗ P ← P ⊗ V₂),
+            SparseBlockTensorMap{TT}(undef, V₂ ⊗ P ← P ⊗ V₁),
+        ]
+        Ws[1][1, 1, 1, 1] = randmpotensor()
+        Ws[2][1, 1, 1, 1] = randmpotensor()
+        Ws[2][2, 1, 1, 2] = randmpotensor()
+        Ws[3][1, 1, 1, 1] = randmpotensor()
+        Ws[3][2, 1, 1, 1] = randmpotensor()
+
+        mpo = MPO(Ws)
+        @test isfinite(mpo)
+        O = convert(TensorMap, mpo)
+        remove_orphans!(mpo)
+
+        @test left_virtualspace(mpo) == right_virtualspace(mpo) == fill(SumSpace(ℂ^1), 3)
+        @test convert(TensorMap, mpo) ≈ O
+    end
 end
 
 @testset "Adapt" for V in (ℂ^2, U1Space(-1 => 1, 0 => 1, 1 => 1))


### PR DESCRIPTION
Fixes #483.

## The bug

`src/operators/abstractmpo.jl:79` set the `changed` flag that drives the fixed-point loop in the **infinite** branch of `remove_orphans!` when *nothing* was removed, instead of when something was:

```julia
changed |= length(mask) == size(mpo[i], 4)   # should be `!=`
```

`mask` lists the *surviving* columns, so `length(mask) == size(mpo[i], 4)` means "no column was dropped".
Two consequences, in opposite directions:

* **Hang** when there is nothing (left) to remove on at least one site — `changed` is set on every pass, so the `while` spins forever.
* **Premature exit** when every site drops something — `changed` stays `false` after the first pass, so the fixed point is never iterated, even though removing a column on site `i` can orphan further columns on site `i ± 1`.

The second is the path `make_time_mpo(H::InfiniteMPOHamiltonian, dt, TaylorCluster())` takes, which is why the suite was green: it returned fine, it just left orphans behind.

## The fix

One character, `==` → `!=`.

## Tests

New `@testset "remove_orphans!"` in `test/operators/mpo.jl`, three cases:

* *infinite: dead-end chain* — a 1-site unit cell with channels `1→1` and `1→2→3→4`, where 4 is a dead end.
  Removing 4 orphans 3, then 2, so the fixed point takes four passes and only the `(1,1)` self-loop may survive.
  Against the unfixed source this fails on the virtual space and the nonzero keys (3-dimensional, two orphan blocks left).
* *infinite: nothing to remove* — the issue's reproducer, as an infinite transverse-field Ising Hamiltonian converted to a plain `SparseMPO`; spaces and nonzero keys must come back untouched.
  Against the unfixed source this hangs.
* *finite: dead-end chain* — guards the unaffected finite branch: a 3-site MPO with an unreachable channel shrinks to bond dimension 1 with the dense operator unchanged.

The finite branch needs no fix: row-slicing at site `i` keeps every nonempty row, so it never removes a block from site `i` itself — it only empties rows of site `i - 1`, which the backward sweep visits next.
One forward plus one backward sweep already is a fixed point.

## Verification

Ran locally: `test/operators/mpo.jl`, `test/operators/dense_mpo.jl`, `test/algorithms/taylorcluster.jl` (40/40), `test/algorithms/timestep.jl` — all green.
`taylorcluster.jl` matters here because `make_time_mpo` on an infinite Hamiltonian now actually iterates to the fixed point, so its output can be smaller than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)