### PR TITLE
docs: add 20 publications that used MPSKit to the bibliography

### DIFF
--- a/docs/src/assets/mpskit.bib
+++ b/docs/src/assets/mpskit.bib
@@ -1,3 +1,17 @@
+@misc{basumatary2026,
+  title = {Cosmological Correlators Using Tensor Networks},
+  author = {Basumatary, Ujjwal and Sinha, Aninda and Zhou, Xinan},
+  year = {2026},
+  month = mar,
+  number = {arXiv:2603.26090},
+  eprint = {2603.26090},
+  primaryclass = {hep-th},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2603.26090},
+  url = {https://arxiv.org/abs/2603.26090},
+  archiveprefix = {arXiv}
+}
+
 @article{belyansky2024,
   title = {High-{{Energy Collision}} of {{Quarks}} and {{Mesons}} in the {{Schwinger Model}}: {{From Tensor Networks}} to {{Circuit QED}}},
   shorttitle = {High-{{Energy Collision}} of {{Quarks}} and {{Mesons}} in the {{Schwinger Model}}},
@@ -12,6 +26,20 @@
   doi = {10.1103/PhysRevLett.132.091903},
   url = {https://link.aps.org/doi/10.1103/PhysRevLett.132.091903},
   abstract = {With the aim of studying nonperturbative out-of-equilibrium dynamics of high-energy particle collisions on quantum simulators, we investigate the scattering dynamics of lattice quantum electrodynamics in 1+1 dimensions. Working in the bosonized formulation of the model and in the thermodynamic limit, we use uniform-matrix-product-state tensor networks to construct multiparticle wave-packet states, evolve them in time, and detect outgoing particles post collision. This facilitates the numerical simulation of scattering experiments in both confined and deconfined regimes of the model at different energies, giving rise to rich phenomenology, including inelastic production of quark and meson states, meson disintegration, and dynamical string formation and breaking. We obtain elastic and inelastic scattering cross sections, together with time-resolved momentum and position distributions of the outgoing particles. Furthermore, we propose an analog circuit-QED implementation of the scattering process that is native to the platform, requires minimal ingredients and approximations, and enables practical schemes for particle wave-packet preparation and evolution. This study highlights the role of classical and quantum simulation in enhancing our understanding of scattering processes in quantum field theories in real time.}
+}
+
+@misc{brehmer2026,
+  title = {{{PEPSKit.jl}}: A {{Julia}} Package for Projected Entangled-Pair State Simulations},
+  author = {Brehmer, Paul and Burgelman, Lander and Yue, Zheng-Yuan and Fedorovich, Gleb and Haegeman, Jutho and Devos, Lukas},
+  year = {2026},
+  month = may,
+  number = {arXiv:2605.19960},
+  eprint = {2605.19960},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2605.19960},
+  url = {https://arxiv.org/abs/2605.19960},
+  archiveprefix = {arXiv}
 }
 
 @article{capponi2025,
@@ -182,6 +210,20 @@
   abstract = {The Affleck-Kennedy-Lieb-Tasaki (AKLT) point of the bilinear-biquadratic spin-1 chain is a cornerstone example of a disorder point where short-range correlations become incommensurate, and correlation lengths and momenta are nonanalytic. While the presence of singularities appears to be generic for AKLT points, we show that for a family of SU⁡({$n$}) models, the AKLT point is not a disorder point: It occurs entirely within an incommensurate phase yet the wave vector remains singular on both sides of the AKLT point. We conjecture that this possibility is generic for models where the representation is not self-conjugate and the transfer matrix non-Hermitian, while for self-conjugate representations the AKLT points remain disorder points.}
 }
 
+@misc{hormann2026,
+  title = {Folds of One Curve: The Superradiant Phase Diagram of {{Dicke}} Modes with Interacting Matter},
+  author = {H{\"o}rmann, Max},
+  year = {2026},
+  month = jun,
+  number = {arXiv:2606.26081},
+  eprint = {2606.26081},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2606.26081},
+  url = {https://arxiv.org/abs/2606.26081},
+  archiveprefix = {arXiv}
+}
+
 @article{jeckelmann2002,
   title = {Dynamical Density-Matrix Renormalization-Group Method},
   author = {Jeckelmann, Eric},
@@ -195,6 +237,34 @@
   doi = {10.1103/PhysRevB.66.045114},
   url = {https://link.aps.org/doi/10.1103/PhysRevB.66.045114},
   abstract = {A density-matrix renormalization-group (DMRG) method for calculating dynamical properties and excited states in low-dimensional lattice quantum many-body systems is presented. The method is based on an exact variational principle for dynamical correlation functions and the excited states contributing to them. This dynamical DMRG is an alternate formulation of the correction vector DMRG but is both simpler and more accurate. The finite-size scaling of spectral functions is discussed and a method for analyzing the scaling of dense spectra is described. The key idea of the method is a size-dependent broadening of the spectrum. The dynamical DMRG and the finite-size scaling analysis are demonstrated on the optical conductivity of the one-dimensional Peierls-Hubbard model. Comparisons with analytical results show that the spectral functions of infinite systems can be reproduced almost exactly with these techniques. The optical conductivity of the Mott-Peierls insulator is investigated and it is shown that its spectrum is qualitatively different from the simple spectra observed in Peierls (band) insulators and one-dimensional Mott-Hubbard insulators.}
+}
+
+@misc{kadow2026,
+  title = {Fractionalization from Kinetic Frustration in Doped Two-Dimensional {{SU}}(4) Quantum Magnets},
+  author = {Kadow, Wilhelm and Morera, Ivan and Demler, Eugene and Knap, Michael},
+  year = {2026},
+  month = mar,
+  number = {arXiv:2603.28871},
+  eprint = {2603.28871},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2603.28871},
+  url = {https://arxiv.org/abs/2603.28871},
+  archiveprefix = {arXiv}
+}
+
+@misc{kaplan2026,
+  title = {Wavelet {{Matrix Product States}} for {{Quantum Fields}}},
+  author = {Kaplan, Molly and Tilloy, Antoine},
+  year = {2026},
+  month = jun,
+  number = {arXiv:2606.23823},
+  eprint = {2606.23823},
+  primaryclass = {quant-ph},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2606.23823},
+  url = {https://arxiv.org/abs/2606.23823},
+  archiveprefix = {arXiv}
 }
 
 @misc{kirchner2025,
@@ -227,6 +297,21 @@
   abstract = {The quantum \$5\$-state Potts model is known to possess a perturbative description using complex conformal field theory (CCFT), the analytic continuation of ``theory space" to a complex plane. To study the corresponding complex fixed point on the lattice, the model must be deformed by an additional non-Hermitian term due to its complex coefficient \$\textbackslash lambda\$. Although the variational principle breaks down in this case, we demonstrate that tensor network algorithms are still capable of simulating these non-Hermitian theories. We access system sizes up to \$L = 28\$, which enable the observation of the theoretically predicted spiral flow of the running couplings. Moreover, we reconstruct the full boundary CCFT spectrum through the entanglement Hamiltonian encoded in the ground state. Our work demonstrates how tensor networks are the correct approach to capturing the approximate conformal invariance of weakly first-order phase transitions.},
   archiveprefix = {arXiv},
   keywords = {Condensed Matter - Strongly Correlated Electrons,Quantum Physics}
+}
+
+% NOTE: MPSKit appears in the bibliography; primary numerics use ITensor.
+@misc{lu2026,
+  title = {Generalized {{Kramers-Wannier Self-Duality}} in {{Hopf-Ising Models}}},
+  author = {Lu, Da-Chuan and Chatterjee, Arkya and Tantivasadakarn, Nathanan},
+  year = {2026},
+  month = feb,
+  number = {arXiv:2602.10183},
+  eprint = {2602.10183},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2602.10183},
+  url = {https://arxiv.org/abs/2602.10183},
+  archiveprefix = {arXiv}
 }
 
 @misc{maertens2025,
@@ -307,6 +392,20 @@
   abstract = {Studies of entanglement in many-particle systems suggest that most quantum critical ground states have infinitely more entanglement than noncritical states. Standard algorithms for one-dimensional systems construct model states with limited entanglement, which are a worse approximation to quantum critical states than to others. We give a quantitative theory of previously observed scaling behavior resulting from finite entanglement at quantum criticality. Finite-entanglement scaling in one-dimensional systems is governed not by the scaling dimension of an operator but by the "central charge" of the critical point. An important ingredient is the universal distribution of density-matrix eigenvalues at a critical point [P. Calabrese and A. Lefevre, Phys. Rev. A 78, 032329 (2008)]. The parameter-free theory is checked against numerical scaling at several quantum critical points.}
 }
 
+@misc{ritter2026,
+  title = {Fast Elementwise Operations on Tensor Trains with Alternating Cross Interpolation},
+  author = {Ritter, Marc K.},
+  year = {2026},
+  month = apr,
+  number = {arXiv:2604.00037},
+  eprint = {2604.00037},
+  primaryclass = {math.NA},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2604.00037},
+  url = {https://arxiv.org/abs/2604.00037},
+  archiveprefix = {arXiv}
+}
+
 @article{rogerson2024,
   title = {Quantum {{Circuit Optimization}} Using {{Differentiable Programming}} of {{Tensor Network States}}},
   author = {Rogerson, David and Roy, Ananda},
@@ -369,6 +468,20 @@
   langid = {english}
 }
 
+@misc{shankar2026,
+  title = {Finite-{{Element Matrix Product States}} for {{Continuum Models}} in {{One Dimension}}},
+  author = {Shankar, Akshay and {Van Acoleyen}, Karel and Haegeman, Jutho},
+  year = {2026},
+  month = jun,
+  number = {arXiv:2606.14873},
+  eprint = {2606.14873},
+  primaryclass = {quant-ph},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2606.14873},
+  url = {https://arxiv.org/abs/2606.14873},
+  archiveprefix = {arXiv}
+}
+
 @misc{shen2025,
   title = {Exploring the Phase Diagram of SU(2)_4 Strange Correlator},
   author = {Shen, Ce},
@@ -383,6 +496,51 @@
   abstract = {We investigate the phase diagram of a quantum many-body system constructed via the strange correlator approach, based on the non-Abelian \$SU(2)\_4\$ fusion category, to probe topological phase transitions. Using tensor network methods, we numerically compute the half-infinite chain entanglement entropy derived from the dominant eigenvector of the transfer matrix and map the entropy across a spherical two-dimensional parameter space. Our results reveal a phase diagram significantly more complex than previously reported, including a gapless phase consistent with a conformal field theory (CFT) of central charge \$c=1\$. Critical lines separating distinct phases are identified, with one such line bounding the CFT phase exhibiting a higher central charge \$c=2\$, indicative of an unconventional critical regime.},
   archiveprefix = {arXiv},
   keywords = {Condensed Matter - Strongly Correlated Electrons,High Energy Physics - Theory}
+}
+
+% NOTE: lecture notes; MPSKit citation not independently confirmed during review.
+@misc{sinha2025,
+  title = {Lectures on Quantum Field Theory on a Quantum Computer},
+  author = {Sinha, Aninda and Basumatary, Ujjwal},
+  year = {2025},
+  month = dec,
+  number = {arXiv:2512.02706},
+  eprint = {2512.02706},
+  primaryclass = {quant-ph},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2512.02706},
+  url = {https://arxiv.org/abs/2512.02706},
+  archiveprefix = {arXiv}
+}
+
+@article{sommer2025,
+  title = {Higher Berry Curvature from the Wave Function. I. {{Schmidt}} Decomposition and Matrix Product States},
+  author = {Sommer, Ophelia Evelyn and Wen, Xueda and Vishwanath, Ashvin},
+  year = {2025},
+  month = apr,
+  journal = {Physical Review Letters},
+  volume = {134},
+  number = {14},
+  pages = {146601},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.134.146601},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.134.146601},
+  eprint = {2405.05316},
+  archiveprefix = {arXiv}
+}
+
+@misc{staelens2026,
+  title = {Combining Matrix Product States and Mean-Field Theory to Capture Magnetic Order in Quasi-1D Cuprates},
+  author = {Staelens, Quentin and Verraes, Daan and Vrancken, Daan and Braeckevelt, Tom and Haegeman, Jutho and {Van Speybroeck}, Veronique},
+  year = {2026},
+  month = feb,
+  number = {arXiv:2602.21695},
+  eprint = {2602.21695},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2602.21695},
+  url = {https://arxiv.org/abs/2602.21695},
+  archiveprefix = {arXiv}
 }
 
 @article{tang2025,
@@ -431,6 +589,34 @@
   langid = {english}
 }
 
+@misc{ueda2026,
+  title = {Emergent {{Andreev Reflection}} from a {{Lattice Duality Defect}}},
+  author = {Ueda, Atsushi and Numasawa, Tokiro and {De Vos}, Boris and Watanabe, Masataka},
+  year = {2026},
+  month = jun,
+  number = {arXiv:2606.23684},
+  eprint = {2606.23684},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2606.23684},
+  url = {https://arxiv.org/abs/2606.23684},
+  archiveprefix = {arXiv}
+}
+
+% NOTE: published SciPost lecture notes; MPSKit citation not independently confirmed during review.
+@article{vancraeynestdecuiper2026,
+  title = {Les {{Houches}} Lecture Notes on Tensor Networks},
+  author = {{Vancraeynest-De Cuiper}, Bram and Wiesiolek, Weronika and Verstraete, Frank},
+  year = {2026},
+  journal = {SciPost Physics Lecture Notes},
+  pages = {128},
+  issn = {2590-1990},
+  doi = {10.21468/SciPostPhysLectNotes.128},
+  url = {https://scipost.org/10.21468/SciPostPhysLectNotes.128},
+  eprint = {2512.24390},
+  archiveprefix = {arXiv}
+}
+
 @article{vandamme2021,
   title = {Efficient Matrix Product State Methods for Extracting Spectral Information on Rings and Cylinders},
   author = {Van Damme, Maarten and Vanhove, Robijn and Haegeman, Jutho and Verstraete, Frank and Vanderstraeten, Laurens},
@@ -477,6 +663,23 @@
   langid = {english}
 }
 
+% NOTE: published Communications Physics; MPSKit citation not independently confirmed during review.
+@article{vandamme2025pseudogenerators,
+  title = {Suppressing Nonperturbative Gauge Errors in the Thermodynamic Limit Using Local Pseudogenerators},
+  author = {{Van Damme}, Maarten and Mildenberger, Julius and Grusdt, Fabian and Hauke, Philipp and Halimeh, Jad C.},
+  year = {2025},
+  month = mar,
+  journal = {Communications Physics},
+  volume = {8},
+  number = {1},
+  pages = {106},
+  publisher = {Springer Nature},
+  doi = {10.1038/s42005-025-02035-y},
+  url = {https://www.nature.com/articles/s42005-025-02035-y},
+  eprint = {2110.08041},
+  archiveprefix = {arXiv}
+}
+
 @article{vanderstraeten2019,
   title = {Tangent-Space Methods for Uniform Matrix Product States},
   author = {Vanderstraeten, Laurens and Haegeman, Jutho and Verstraete, Frank},
@@ -521,6 +724,34 @@
   abstract = {We use the formalism of strange correlators to construct a critical classical lattice model in two dimensions with the Haagerup fusion category {$\mathcal{H}$}3 as input data. We present compelling numerical evidence in the form of finite entanglement scaling to support a Haagerup conformal field theory (CFT) with central charge {$c$} =2. Generalized twisted CFT spectra are numerically obtained through exact diagonalization of the transfer matrix, and the conformal towers are separated in the spectra through their identification with the topological sectors. It is further argued that our model can be obtained through an orbifold procedure from a larger lattice model with input {$Z$}⁡({$\mathcal{H}$}3), which is the simplest modular tensor category that does not admit an algebraic construction. This provides a counterexample for the conjecture that all rational CFT can be constructed from standard methods.}
 }
 
+@misc{vanthilt2026,
+  title = {Matrix {{Product Operator}} Encodings of the {{Magnus Expansion}} and {{Dyson Series}}},
+  author = {Vanthilt, Victor and {Van Damme}, Maarten and Haegeman, Jutho and McCulloch, Ian P. and Vanderstraeten, Laurens},
+  year = {2026},
+  month = may,
+  number = {arXiv:2605.21597},
+  eprint = {2605.21597},
+  primaryclass = {quant-ph},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2605.21597},
+  url = {https://arxiv.org/abs/2605.21597},
+  archiveprefix = {arXiv}
+}
+
+@misc{veitas2026,
+  title = {Fluctuation-Driven Chiral Ferromagnetism},
+  author = {Veitas, Rokas and Khalifa, Ahmed and Machado, Francisco and Chatterjee, Shubhayu},
+  year = {2026},
+  month = may,
+  number = {arXiv:2605.06852},
+  eprint = {2605.06852},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2605.06852},
+  url = {https://arxiv.org/abs/2605.06852},
+  archiveprefix = {arXiv}
+}
+
 @article{vrancken2025,
   title = {Quantitative {{Description}} of {{Strongly Correlated Materials}} by {{Combining Downfolding Techniques}} and {{Tensor Networks}}},
   author = {Vrancken, Daan and Ganne, Simon and Verraes, Daan and Braeckevelt, Tom and Devos, Lukas and Vanderstraeten, Laurens and Haegeman, Jutho and Van Speybroeck, Veronique},
@@ -551,6 +782,20 @@
   doi = {10.1103/PhysRevB.109.L241117},
   url = {https://link.aps.org/doi/10.1103/PhysRevB.109.L241117},
   abstract = {An important class of model Hamiltonians for investigation of topological phases of matter consists of mobile, interacting particles on a lattice subject to a semiclassical gauge field, as exemplified by the bosonic Harper-Hofstadter model. A unique method for investigations of two-dimensional quantum systems are the infinite projected-entangled pair states, as they avoid spurious finite-size effects that can alter the phase structure. However, due to no-go theorems in related cases, this was often conjectured to be impossible in the past. In this Letter, we show that upon variational optimization, the infinite projected-entangled pair states can be used to this end by identifying fractional Hall states in the bosonic Harper-Hofstadter model. The obtained states are characterized by showing exponential decay of bulk correlations, as dictated by a bulk gap, as well as chiral edge modes via the entanglement spectrum.}
+}
+
+@misc{yang2026,
+  title = {Transfer-Matrix Functions for Algebraically Decaying Interactions in Variational Infinite Matrix Product States},
+  author = {Yang, Qi},
+  year = {2026},
+  month = jun,
+  number = {arXiv:2606.20522},
+  eprint = {2606.20522},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2606.20522},
+  url = {https://arxiv.org/abs/2606.20522},
+  archiveprefix = {arXiv}
 }
 
 @article{yu2021,
@@ -600,6 +845,20 @@
   abstract = {We combine the density matrix renormalization group (DMRG) with matrix product state tangent space concepts to construct a variational algorithm for finding ground states of one-dimensional quantum lattices in the thermodynamic limit. A careful comparison of this variational uniform matrix product state algorithm (VUMPS) with infinite density matrix renormalization group (IDMRG) and with infinite time evolving block decimation (ITEBD) reveals substantial gains in convergence speed and precision. We also demonstrate that VUMPS works very efficiently for Hamiltonians with long-range interactions and also for the simulation of two-dimensional models on infinite cylinders. The new algorithm can be conveniently implemented as an extension of an already existing DMRG implementation.}
 }
 
+@misc{zemlevskiy2026,
+  title = {Exclusive Scattering Channels from Entanglement Structure in Real-Time Simulations},
+  author = {Zemlevskiy, Nikita A.},
+  year = {2026},
+  month = mar,
+  number = {arXiv:2603.15621},
+  eprint = {2603.15621},
+  primaryclass = {quant-ph},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2603.15621},
+  url = {https://arxiv.org/abs/2603.15621},
+  archiveprefix = {arXiv}
+}
+
 @article{zhang2023,
   title = {Universal {{Scaling}} of {{Klein Bottle Entropy}} near {{Conformal Critical Points}}},
   author = {Zhang, Yueshui and Hulsch, Anton and Zhang, Hua-Chen and Tang, Wei and Wang, Lei and Tu, Hong-Hao},
@@ -613,6 +872,37 @@
   doi = {10.1103/PhysRevLett.130.151602},
   url = {https://link.aps.org/doi/10.1103/PhysRevLett.130.151602},
   abstract = {We show that the Klein bottle entropy [H.-H. Tu, Phys. Rev. Lett. 119, 261603 (2017)] for conformal field theories perturbed by a relevant operator is a universal function of the dimensionless coupling constant. The universal scaling of the Klein bottle entropy near criticality provides an efficient approach to extract the scaling dimension of lattice operators via data collapse. As paradigmatic examples, we validate the universal scaling of the Klein bottle entropy for Ising and {$\mathbb{Z}$}3 parafermion conformal field theories with various perturbations using numerical simulation with continuous matrix product operator approach.}
+}
+
+@misc{zong2026nickelate,
+  title = {Correlation-Driven Orbital-Selective Fermiology and Superconductivity in the Bilayer Nickelate {{La}}$_3${{Ni}}$_2${{O}}$_7$},
+  author = {Zong, Yong-Yue and Yu, Shun-Li and Li, Jian-Xin},
+  year = {2026},
+  month = may,
+  number = {arXiv:2605.10101},
+  eprint = {2605.10101},
+  primaryclass = {cond-mat.str-el},
+  publisher = {arXiv},
+  doi = {10.48550/arXiv.2605.10101},
+  url = {https://arxiv.org/abs/2605.10101},
+  archiveprefix = {arXiv}
+}
+
+% NOTE: published PRX; MPSKit citation not independently confirmed during review (uses DMRG).
+@article{zong2026pseudogap,
+  title = {Pseudogap with {{Fermi Arcs}} and {{Fermi Pockets}} in Half-Filled Twisted Transition Metal Dichalcogenides},
+  author = {Zong, Yong-Yue and Gu, Zhao-Long and Li, Jian-Xin},
+  year = {2026},
+  month = jan,
+  journal = {Physical Review X},
+  volume = {16},
+  number = {1},
+  pages = {011005},
+  publisher = {American Physical Society},
+  doi = {10.1103/kmn8-y59j},
+  url = {https://link.aps.org/doi/10.1103/kmn8-y59j},
+  eprint = {2406.11374},
+  archiveprefix = {arXiv}
 }
 
 @article{Hubig2015,

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -6,6 +6,29 @@ Below you can find a list of publications that have made use of MPSKit. If you h
 this package and wish to have your publication added to this list, please open a pull
 request or an issue on the [GitHub repository](https://github.com/QuantumKitHub/MPSKit.jl/).
 
+### 2026
+
+```@bibliography
+Pages = []
+basumatary2026
+brehmer2026
+hormann2026
+kadow2026
+kaplan2026
+lu2026
+ritter2026
+shankar2026
+staelens2026
+ueda2026
+vancraeynestdecuiper2026
+vanthilt2026
+veitas2026
+yang2026
+zemlevskiy2026
+zong2026nickelate
+zong2026pseudogap
+```
+
 ### 2025
 
 ```@bibliography
@@ -15,10 +38,13 @@ dempsey2025
 herviou2025
 kirchner2025
 linden2025
-mortier2025
 maertens2025
+mortier2025
 shen2025
+sinha2025
+sommer2025
 ueda2025
+vandamme2025pseudogenerators
 vrancken2025
 ```
 ### 2024


### PR DESCRIPTION
Bibliography slice of #449. Two files, no package source.

- `mpskit.bib`: 41 → 61 entries, adding 20 works that use MPSKit, in the file's existing alphabetical-by-key order.
- `references.md`: new `### 2026` section, three additions to `### 2025`, one alphabetical fix.

Five entries carry an inline `%` note where the MPSKit citation could not be confirmed while collecting them — worth a glance. `tang2025` is cited nowhere at all, but that predates this PR (#344) and is left alone.

The `gleis2023` entry and the `Hubig2015` → `hubig2015` rename are in #488 instead, since its docstrings cite them. Expect a one-line conflict there on that key; take lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
