### PR TITLE
`dot` shortcut for `FiniteMPS`

### DIFF
--- a/src/algorithms/expval.jl
+++ b/src/algorithms/expval.jl
@@ -65,18 +65,18 @@ function expectation_value(ψ::AbstractMPS, (inds, O)::Pair)
 
     # right side
     E = @plansor removeunit(M, 2)[1; 2] * ψ.C[sites[end]][2; 3] * conj(ψ.C[sites[end]][1; 3])
-    return E / dot(ψ, ψ)
+    return E / norm(ψ)^2
 end
 
 function local_expectation_value1(ψ::AbstractMPS, site, O)
     E = contract_mpo_expval1(ψ.AC[site], O, ψ.AC[site])
-    return E / dot(ψ, ψ)
+    return E / norm(ψ)^2
 end
 function local_expectation_value2(ψ::AbstractMPS, site, O)
     AC = ψ.AC[site]
     AR = ψ.AR[site + 1]
     E = contract_mpo_expval2(AC, AR, O, AC, AR)
-    return E / dot(ψ, ψ)
+    return E / norm(ψ)^2
 end
 
 # MPOHamiltonian
@@ -125,14 +125,14 @@ function expectation_value(
         ψ::FiniteMPS, H::FiniteMPOHamiltonian,
         envs::AbstractMPSEnvironments = environments(ψ, H, ψ)
     )
-    return dot(ψ, H, ψ, envs) / dot(ψ, ψ)
+    return dot(ψ, H, ψ, envs) / norm(ψ)^2
 end
 
 function expectation_value(
         ψ::WindowMPS, H::WindowMPOHamiltonian,
         envs::AbstractMPSEnvironments = environments(ψ, H)
     )
-    return dot(ψ, H, ψ, envs) / dot(ψ, ψ)
+    return dot(ψ, H, ψ, envs) / norm(ψ)^2
 end
 
 function expectation_value(
@@ -163,7 +163,7 @@ end
 # DenseMPO
 # --------
 function expectation_value(ψ::FiniteMPS, mpo::FiniteMPO)
-    return dot(ψ, mpo, ψ) / dot(ψ, ψ)
+    return dot(ψ, mpo, ψ) / norm(ψ)^2
 end
 function expectation_value(ψ::FiniteQP, mpo::FiniteMPO)
     return expectation_value(convert(FiniteMPS, ψ), mpo)

--- a/src/states/finitemps.jl
+++ b/src/states/finitemps.jl
@@ -589,6 +589,9 @@ end
 function TensorKit.dot(ψ₁::FiniteMPS, ψ₂::FiniteMPS)
     #todo : rewrite this without having to gauge
     length(ψ₁) == length(ψ₂) || throw(ArgumentError("MPS with different length"))
+    if ψ₁ === ψ₂
+        return convert(Base.promote_op(inner, scalartype(ψ₁), scalartype(ψ₂)), norm(ψ₁)^2)
+    end
     ρr = TransferMatrix(ψ₂.AR[2:end], ψ₁.AR[2:end]) * r_RR(ψ₂)
     return tr(_transpose_front(ψ₁.AC[1])' * _transpose_front(ψ₂.AC[1]) * ρr)
 end

--- a/test/states/finitemps.jl
+++ b/test/states/finitemps.jl
@@ -36,9 +36,10 @@ using Adapt
 
     @test eltype(ψ) == eltype(typeof(ψ))
 
-    ovl = dot(ψ, ψ)
+    ovl = @constinferred dot(ψ, ψ)
 
     @test ovl ≈ norm(ψ.AC[1])^2
+    @test ovl isa scalartype(ψ)
 
     for i in 1:length(ψ)
         @test ψ.AC[i] ≈ ψ.AL[i] * ψ.C[i]


### PR DESCRIPTION
Slightly cheaper this way, and matters somewhat in expectation value calls.