### PR TITLE
Add `DynamicTols` and `Defaults` submodules to library documentation

### DIFF
--- a/docs/src/lib/lib.md
+++ b/docs/src/lib/lib.md
@@ -1,5 +1,5 @@
 # Library documentation
 
 ```@autodocs
-Modules = [MPSKit]
+Modules = [MPSKit, MPSKit.DynamicTols, MPSKit.Defaults]
 ```


### PR DESCRIPTION
The library documentation currently only includes autodocs for the main `MPSKit` module, but not for any of its submodules such as `MPSKit.DynamicTols` and `MPSKit.Defaults`. I think it would be better to add these submodules to the library docs, since they definitely contain useful docstrings. For example, I personally wanted to refer to `MPSKit.DyamicTols.DynamicTol` from another project, but now also `MPSKit.Defaults.set_buffering!` is referred to from the manual docs but the docstring itself is not available.