### PR TITLE
Fix `ZipUp` for sparse MPOs

### DIFF
--- a/src/operators/mpo.jl
+++ b/src/operators/mpo.jl
@@ -304,7 +304,7 @@ Fuse the left virtual legs of the product of MPO-MPS tensors
 """
 function _fuse_mpo_mps_left(O::MPOTensor, A::MPSTensor, Fₗ)
     @plansor A′[-1 -2; -3 -4] := Fₗ[-1; 1 3] * A[1 2; -3] * O[3 -2; 2 -4]
-    return A′ isa AbstractBlockTensorMap ? TensorMap(A′) : A′
+    return A′
 end
 """
 Fuse the right virtual legs of the product of MPO-MPS tensors
@@ -320,7 +320,7 @@ function _fuse_mpo_mps_right(O::MPOTensor, A::MPSTensor, Fᵣ)
     # the resulting tensor is partitioned across the new bond
     # `_transpose_front` of the right factor is again an MPS tensor
     @plansor A′[-1 -2; -3 -4] := A[-1 1; 2] * O[-2 -4; 1 3] * Fᵣ[2 3; -3]
-    return A′ isa AbstractBlockTensorMap ? TensorMap(A′) : A′
+    return A′
 end
 
 function Base.:*(mpo::FiniteMPO{<:MPOTensor}, x::AbstractTensorMap)

--- a/test/algorithms/approximate.jl
+++ b/test/algorithms/approximate.jl
@@ -19,9 +19,8 @@ zipup_spacelist = [
     (Rep[SU₂](1 => 1), Rep[SU₂](0 => 2, 1 => 2, 2 => 1), 8),
 ]
 
-function _random_mpo_mps(pspace, Dspace; elt = ComplexF64)
+function _random_mpo_mps(pspace, Dspace, L; elt = ComplexF64)
     Random.seed!(1357)
-    L = 6
     Wspace = Dspace
     Vspaces = [oneunit(Wspace); fill(Wspace, L - 1); oneunit(Wspace)]
     O = FiniteMPO(
@@ -107,7 +106,10 @@ end
     end
 
     @testset "Finite MPO-MPS zip-up $(spacetype(pspace))" for (pspace, Dspace, _) in zipup_spacelist
-        O, ψ = _random_mpo_mps(pspace, Dspace)
+        L = 6
+
+        # dense MPO
+        O, ψ = _random_mpo_mps(pspace, Dspace, L)
         O_copy = copy(O)
         ψ_copy = copy(ψ)
 
@@ -123,11 +125,31 @@ end
 
         @test norm(ψ - ψ_copy) < 1.0e-12
         @test all(i -> norm(O[i] - O_copy[i]) < 1.0e-12, 1:length(O))
+
+        # sparse MPO
+        nn = rand(ComplexF64, pspace * pspace, pspace * pspace)
+        nn += nn'
+        H = FiniteMPOHamiltonian(fill(pspace, L), (i, i + 1) => nn for i in 1:(L - 1))
+        τ = 1.0e-3
+        expH = make_time_mpo(H, τ, WI)
+
+        # reference via TDVP
+        ref_s, = timestep(ψ, H, 0.0, τ, TDVP())
+        normalize!(ref_s)
+
+        # both sweep directions, with and without the zip-down pass
+        for left_to_right in (true, false), trunc′ in (trunc, (notrunc(), trunc))
+            got_s, ϵ = approximate((expH, ψ), Zipup(; trunc = trunc′, left_to_right))
+            normalize!(got_s)
+            @test norm(ref_s - got_s) < 0.002
+            @test norm(ψ - got_s) > 0.002
+            @test ϵ < 1.0e-10
+        end
     end
 
     @testset "Paeckel two-stage zip-up $(spacetype(pspace)), left_to_right = $left_to_right" for
         (pspace, Dspace, Dcut) in zipup_spacelist, left_to_right in (true, false)
-        O, ψ = _random_mpo_mps(pspace, Dspace)
+        O, ψ = _random_mpo_mps(pspace, Dspace, 6)
         rtol = 1.0e-8
         final_trunc = truncrank(Dcut) & truncerror(; rtol)
         zipup_trunc = truncrank(2Dcut) & truncerror(; rtol = rtol / 10)
@@ -148,7 +170,7 @@ end
 
     @testset "In-place zip-up $(spacetype(pspace)), left_to_right = $left_to_right" for
         (pspace, Dspace, Dcut) in zipup_spacelist, left_to_right in (true, false)
-        O, ψ = _random_mpo_mps(pspace, Dspace)
+        O, ψ = _random_mpo_mps(pspace, Dspace, 6)
         alg = Zipup(; trunc = (truncrank(2Dcut), truncrank(Dcut)), left_to_right)
         ref, ϵ_ref = approximate((O, ψ), alg)
 
@@ -218,7 +240,7 @@ end
     end
 
     @testset "Zip-up scalar type promotion $(spacetype(pspace))" for (pspace, Dspace, _) in zipup_spacelist
-        O, ψ = _random_mpo_mps(pspace, Dspace; elt = Float64)
+        O, ψ = _random_mpo_mps(pspace, Dspace, 6; elt = Float64)
         alg = Zipup(; trunc = trunctol(; atol = 1.0e-10))
 
         got, _ = approximate((O, ψ), alg)


### PR DESCRIPTION
## Description

Fixes #496.

I just removed the `BlockTensorMap -> TensorMap` conversion in the local contractions.

## Checklist

- [x] Tests pass locally (`julia --project=test test/runtests.jl`, or the relevant subset)
- [x] Documentation updated, if this PR changes public API (docstrings, `docs/src/`)
- [x] Runic formatter is run
- [x] Changelog entry added under `[Unreleased]` in `docs/src/changelog.md`, if this PR is user-facing (new feature, behavior change, bug fix, deprecation, or removal)
