### PR TITLE
Fix broken logging calls in `time_evolve`

### DIFF
--- a/src/algorithms/timestep/time_evolve.jl
+++ b/src/algorithms/timestep/time_evolve.jl
@@ -37,7 +37,7 @@ for (timestep, time_evolve) in zip((:timestep, :timestep!), (:time_evolve, :time
         )
         log = IterLog("TDVP")
         LoggingExtras.withlevel(; verbosity) do
-            @infov 2 loginit!(log, 0, first(t_span))
+            @infov 2 loginit!(log, 0.0, first(t_span))
             for iter in 1:(length(t_span) - 1)
                 t = t_span[iter]
                 dt = t_span[iter + 1] - t
@@ -45,9 +45,9 @@ for (timestep, time_evolve) in zip((:timestep, :timestep!), (:time_evolve, :time
                 ψ, envs = $timestep(ψ, H, t, dt, alg, envs; imaginary_evolution, normalize)
                 ψ, envs = alg.finalize(t, ψ, H, envs)::Tuple{typeof(ψ), typeof(envs)}
 
-                @infov 3 logiter!(log, iter, 0, t)
+                @infov 3 logiter!(log, iter, 0.0, t)
             end
-            @infov 2 logfinish!(log, length(t_span), 0, t_span[end])
+            @infov 2 logfinish!(log, length(t_span), 0.0, t_span[end])
         end
         return ψ, envs
     end

--- a/test/algorithms/timestep.jl
+++ b/test/algorithms/timestep.jl
@@ -273,7 +273,7 @@ end
     E₀ = expectation_value(ψ₀, H)
 
     @testset "Finite $(algname(alg))" for alg in algs
-        ψ, envs = time_evolve(ψ₀, H, t_span, alg)
+        ψ, envs = time_evolve(ψ₀, H, t_span, alg; verbosity = 2)
         E = expectation_value(ψ, H, envs)
         @test E₀ ≈ E atol = 1.0e-2
     end
@@ -283,7 +283,7 @@ end
     E₀ = expectation_value(ψ₀, H)
 
     @testset "Infinite TDVP" begin
-        ψ, envs = time_evolve(ψ₀, H, t_span, TDVP())
+        ψ, envs = time_evolve(ψ₀, H, t_span, TDVP(); verbosity = 2)
         E = expectation_value(ψ, H, envs)
         @test E₀ ≈ E atol = 1.0e-2
     end


### PR DESCRIPTION
Previously `time_evolve` called the logging functions with an error set to zero, e.g. `loginit!(log, 0, first(t_span))`. However, the error is type restricted to a `Float64` in the `IterativeLoggers` submodule, leading to a method error. I just added a decimal point to avoid this, and added some non-trivial verbosity in the existing `time_evolve` tests to check the effect.