### PR TITLE
[fix] Update edge tensors accordingly in leading boundary with IDMRG2

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -96,6 +96,7 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
   and the right virtual leg of `mpo[end]` and contracted the two — which at length 1 is the *same*
   tensor, so it returned `O * O` on twice the physical space instead of `O`.
   ([#484](https://github.com/QuantumKitHub/MPSKit.jl/pull/484))
+- `leading_boundary` with `IDMRG2` didn't update the left edge of the AC tensor, which could result in space mismatches depending on the truncation scheme. This is corrected for in ([#516](https://github.com/QuantumKitHub/MPSKit.jl/pull/516)).
 
 ### Performance
 

--- a/src/algorithms/statmech/idmrg.jl
+++ b/src/algorithms/statmech/idmrg.jl
@@ -149,6 +149,7 @@ function leading_boundary(
 
             # update the edge
             ψ.AC[:, end] .= _mul_front.(ψ.C[:, end - 1], ψ.AR[:, end])
+            ψ.AC[:, 1] .= _mul_tail.(ψ.AL[:, 1], ψ.C[:, 1])
             ψ.AR[:, 1] .= _transpose_front.(ψ.C[:, end] .\ _transpose_tail.(ψ.AC[:, 1]))
             ac2 = AC2(ψ, 0; kind = :ACAR)
             h = AC2_hamiltonian(0, ψ, operator, ψ, envs; alg.backend, allocator)

--- a/test/algorithms/groundstate.jl
+++ b/test/algorithms/groundstate.jl
@@ -481,4 +481,15 @@ end
             @test expectation_value(ψ, mpo, envs) ≈ 2.5337 atol = 1.0e-3
         end
     end
+
+    @testset "IDMRG2 growing bond dimension" begin
+        Random.seed!(1234)
+        V = Vect[Z2Irrep](0 => 1, 1 => 1)
+        O = randn(ComplexF64, V ⊗ V, V ⊗ V)
+        mpo = InfiniteMPO([O, O])
+        P = physicalspace(O)
+        ψ₀ = InfiniteMPS([P, P], [V, V])
+        ψ, envs = leading_boundary(ψ₀, mpo, IDMRG2(; verbosity = 0, maxiter = 1, trunc = truncrank(8)))
+        @test ψ isa InfiniteMPS
+    end
 end


### PR DESCRIPTION
## Description

Leading boundary with IDMRG2 forgot to update one of the tensors in the right-to-left sweep, which caused space mismatches.
The test I added could've been put in the old bugs section, but where I put it has most of the code already compiled so it's less straining for CI. 

This was not caught before I guess because in other cases the rank just saturates immediately, so pre-updated data in the sweeps don't space mismatch.

## Checklist

- [ ] Tests pass locally (`julia --project=test test/runtests.jl`, or the relevant subset)
- [ ] Documentation updated, if this PR changes public API (docstrings, `docs/src/`)
- [x] Runic formatter is run
- [x] Changelog entry added under `[Unreleased]` in `docs/src/changelog.md`, if this PR is user-facing (new feature, behavior change, bug fix, deprecation, or removal)
