### PR TITLE
fix: address norm issues in MPO compression

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -85,6 +85,12 @@ When releasing a new version, move the "Unreleased" changes to a new version sec
 
 ### Fixed
 
+- `changebonds(::FiniteMPO, ::SvdCut)` truncated long chains down to a zero operator. It now gauges
+  in a separate sweep, spreads the operator norm evenly over the sites, and truncates against the
+  per-bond reference scale `‖O‖^(2/length(mpo))`.
+- `changebonds(::FiniteMPOHamiltonian, ::SvdCut)` threw a `BoundsError` for Hamiltonians with
+  long-range terms.
+- `SvdCut` now warns when a truncation empties a bond, instead of silently returning a zero operator.
 - `isfinite(::WindowMPOHamiltonian)` was undefined. ([#489](https://github.com/QuantumKitHub/MPSKit.jl/pull/489))
 - `excitations(::InfiniteMPO, ::QuasiparticleAnsatz, ::InfiniteQP, lenvs, renvs)` referenced `H_eff`  before assigning. ([#489](https://github.com/QuantumKitHub/MPSKit.jl/pull/489))
 - `Base.:+`/`-` on `FiniteMPS` returned a wrong state for near-parallel operands carried by

--- a/src/algorithms/changebonds/svdcut.jl
+++ b/src/algorithms/changebonds/svdcut.jl
@@ -4,11 +4,14 @@ $(TYPEDEF)
 An algorithm that uses truncated SVD to change the bond dimension of a state or operator.
 This is achieved by a sweeping algorithm that locally performs (optimal) truncations in a gauged basis.
 
-changedbonds! is only defined for FiniteMPS and FiniteMPO.
-
 # Fields
 
 $(TYPEDFIELDS)
+
+# Truncation scale
+
+For an `MPO` the norm is gauged out and spread evenly over the sites, so every truncated bond sees the same reference scale `‖O‖^(2/length(mpo))`.
+An `MPOHamiltonian` is instead truncated in the Jordan basis with the identity level projected out, where the singular values carry the scale of the interactions crossing that bond.
 
 # See also
 
@@ -46,43 +49,63 @@ function changebonds!(ψ::AbstractFiniteMPS, H, alg::SvdCut, envs)
     return ψ, envs
 end
 
-# Note: it might be better to go to an MPS representation first
-# such that the SVD cut happens in a canonical form;
-# this would still not be the correct norm, so we will ignore this for now.
-# this implementation cuts the bond dimension in a non-canonical basis from left to right,
-# but then the basis would be somewhat canonical automatically, so in the reverse direction
-# we can cut the bond dimension in a canonical basis?
 changebonds(mpo::FiniteMPO, alg::SvdCut) = changebonds!(copy(mpo), alg)
 function changebonds!(mpo::FiniteMPO, alg::SvdCut)
-    # cannot cut a MPO with only one site
-    length(mpo) == 1 && return mpo
+    N = length(mpo)
+    N == 1 && return mpo
 
-    # left to right
-    O_left = transpose(mpo[1], ((3, 1, 2), (4,)))
-    local O_right
-    for i in 2:length(mpo)
-        U, S, Vᴴ = svd_trunc!(O_left; trunc = alg.trunc, alg = alg.alg_svd)
-        @inbounds mpo[i - 1] = transpose(U, ((2, 3), (1, 4)))
-        if i < length(mpo)
-            @plansor O_left[-3 -1 -2; -4] := S[-1; 1] * Vᴴ[1; 2] * mpo[i][2 -2; -3 -4]
+    # gauge left to right, keeping the total norm out of band
+    logS = zero(float(real(scalartype(mpo))))
+    local carry
+    for i in 1:(N - 1)
+        if i == 1
+            A = transpose(mpo[1], ((3, 1, 2), (4,)))
         else
-            @plansor O_right[-1; -3 -4 -2] := S[-1; 1] * Vᴴ[1; 2] * mpo[end][2 -2; -3 -4]
+            @plansor A[-3 -1 -2; -4] := carry[-1; 1] * mpo[i][1 -2; -3 -4]
         end
+        Q, carry = left_orth!(A)
+        logS += _extract_norm!(carry)
+        @inbounds mpo[i] = transpose(Q, ((2, 3), (1, 4)))
+    end
+    @plansor A[-1 -2; -3 -4] := carry[-1; 1] * mpo[N][1 -2; -3 -4]
+    logS += _extract_norm!(A)
+    @inbounds mpo[N] = A
+
+    # spread it evenly, so that every bond of the truncation sweep sees the same scale
+    f = exp(logS / N)
+    for i in 1:N
+        @inbounds scale!(mpo[i], f)
     end
 
-    # right to left
-    for i in (length(mpo) - 1):-1:1
-        U, S, Vᴴ = svd_trunc!(O_right; trunc = alg.trunc, alg = alg.alg_svd)
-        @inbounds mpo[i + 1] = transpose(Vᴴ, ((1, 4), (2, 3)))
+    # truncate right to left, splitting the carry norm evenly across each bond
+    O = transpose(mpo[N], ((1,), (3, 4, 2)))
+    for i in (N - 1):-1:1
+        U, S, Vᴴ = svd_trunc!(O; trunc = alg.trunc, alg = alg.alg_svd)
+        _warn_empty_bond(i, space(S, 1))
+        n = sqrt(norm(S))
+        iszero(n) && (n = one(n))
+        @inbounds mpo[i + 1] = transpose(scale!(Vᴴ, n), ((1, 4), (2, 3)))
         if i > 1
-            @plansor O_right[-1; -3 -4 -2] := mpo[i][-1 -2; -3 2] * U[2; 1] * S[1; -4]
+            @plansor O[-1; -3 -4 -2] := mpo[i][-1 -2; -3 2] * U[2; 1] * S[1; -4] / n
         else
-            @plansor _O[-1 -2; -3 -4] := mpo[1][-1 -2; -3 2] * U[2; 1] * S[1; -4]
-            @inbounds mpo[1] = _O
+            @plansor mpo[1][-1 -2; -3 -4] := mpo[1][-1 -2; -3 2] * U[2; 1] * S[1; -4] / n
         end
     end
 
     return mpo
+end
+
+# scale `t` to unit norm, returning the log of the factor that was divided out
+function _extract_norm!(t)
+    n = norm(t)
+    (iszero(n) || !isfinite(n)) && return zero(float(real(typeof(n))))
+    scale!(t, inv(n))
+    return log(n)
+end
+
+function _warn_empty_bond(bond::Int, V)
+    dim(V) == 0 && @warn "`SvdCut` truncated the bond between sites $bond and $(bond + 1) down to zero dimensions; the resulting operator is identically zero. Loosen `trunc` or check the scale of the input operator."
+    return nothing
 end
 
 # TODO: this assumes the MPO is infinite, and does weird things for finite MPOs.
@@ -130,6 +153,9 @@ function changebonds!(H::FiniteMPOHamiltonian, alg::SvdCut)
         H = right_canonicalize!(H, i)
     end
 
+    # a Jordan bond has a start and a finish level on top of its interaction channels
+    channels_before = [dim(left_virtualspace(H, i)) - 2 for i in 2:length(H)]
+
     # swipe right
     alg_trunc = MatrixAlgebraKit.TruncatedAlgorithm(alg.alg_svd, alg.trunc)
     for i in 1:(length(H) - 1)
@@ -139,6 +165,12 @@ function changebonds!(H::FiniteMPOHamiltonian, alg::SvdCut)
     for i in length(H):-1:2
         H = right_canonicalize!(H, i; alg = MatrixAlgebraKit.RightOrthViaSVD(alg_trunc))
     end
+
+    emptied = findall(
+        i -> channels_before[i] > 0 && dim(left_virtualspace(H, i + 1)) - 2 == 0,
+        eachindex(channels_before)
+    )
+    isempty(emptied) || @warn "`SvdCut` discarded every interaction crossing bond(s) $(emptied .+ 1); those terms are gone from the compressed operator. Loosen `trunc` or check the scale of the input Hamiltonian."
 
     return H
 end

--- a/src/operators/ortho.jl
+++ b/src/operators/ortho.jl
@@ -1,3 +1,7 @@
+# TODO: no `add!` exists for this mixed pair yet, and the fallback breaks on zero-length blocks
+_dense(t::SparseBlockTensorMap) = BlockTensorMap(t)
+_dense(t) = t
+
 function left_canonicalize!(
         H::FiniteMPOHamiltonian, i::Int;
         alg::MatrixAlgebraKit.AbstractAlgorithm = Defaults.alg_orth()
@@ -21,7 +25,7 @@ function left_canonicalize!(
     # TODO: the following is currently broken due to a TensorKit bug
     # @plansor C′[p; p' r] := WC[p; p' r] - WI[p; p' l] * t[l; r]
     @plansor C′[p; p' r] := -WI[p; p' l] * t[l; r]
-    add!(C′, WC)
+    add!(C′, _dense(WC))
 
     # QR of second column
     if size(W, 1) == 1
@@ -71,7 +75,7 @@ function left_canonicalize!(
 
     if size(W′, 4) > 1
         @plansor C′[l p; p' r] := t[l; r'] * W′A[r' p; p' r]
-        C′ = add!(removeunit(C′, 1), W′C)
+        C′ = add!(removeunit(C′, 1), _dense(W′C))
     else
         C′ = W′C # empty
     end
@@ -83,7 +87,7 @@ function left_canonicalize!(
     end
 
     @plansor D′[l p; p'] := t[l; r] * W′B[r p; p']
-    D′ = add!(removeunit(D′, 1), W′D)
+    D′ = add!(removeunit(D′, 1), _dense(W′D))
 
     H[i + 1] = JordanMPOTensor(
         right_virtualspace(H[i]) ⊗ physicalspace(W′) ← domain(W′),
@@ -115,7 +119,7 @@ function right_canonicalize!(
     # TODO: the following is currently broken due to a TensorKit bug
     # @plansor B′[l p; p'] := WB[l p; p'] - WI[r p; p'] * t[l; r]
     @plansor B′[l p; p'] := -WI[r p; p'] * t[l; r]
-    add!(B′, WB)
+    add!(B′, _dense(WB))
 
     # LQ of second row
     if size(W, 4) == 1
@@ -165,7 +169,7 @@ function right_canonicalize!(
 
     if size(W′, 1) > 1
         @plansor B′[l p; p' r] := W′A[l p; p' r'] * t[r'; r]
-        B′ = add!(removeunit(B′, 4), W′B)
+        B′ = add!(removeunit(B′, 4), _dense(W′B))
     else
         B′ = W′B
     end
@@ -177,7 +181,7 @@ function right_canonicalize!(
     end
 
     @plansor D′[p; p' r] := W′C[p; p' r'] * t[r'; r]
-    D′ = add!(removeunit(D′, 3), W′D)
+    D′ = add!(removeunit(D′, 3), _dense(W′D))
     H[i - 1] = JordanMPOTensor(codomain(W′) ← physicalspace(W′) ⊗ V, A′, B′, C′, D′)
     return H
 end

--- a/test/algorithms/changebonds.jl
+++ b/test/algorithms/changebonds.jl
@@ -193,3 +193,49 @@ end
 
     @test dim(left_virtualspace(state_tr, 1, 1)) < dim(left_virtualspace(state_oe, 1, 1))
 end
+
+# Regression: the `FiniteMPO` `SvdCut` sweep used to absorb `S * Vᴴ` into the next site without
+# renormalizing, so the carried gauge tensor grew by `sqrt(dim(P))` per site. Once its singular
+# values passed `sqrt(floatmax)`, `TensorKit`'s block-wise norm overflowed and a relative `trunc`
+# discarded *every* singular value, silently returning a zero operator.
+@testset "SvdCut scale overflow (long FiniteMPO)" begin
+    Random.seed!(1234)
+    pspace = ℙ^16
+    L = 300    # (sqrt(dim(P)))^L must exceed sqrt(floatmax) to trigger the old overflow
+    h = rand(ComplexF64, pspace, pspace)
+    h += h'
+    nn = h ⊗ h    # keep the term low-rank so that the dense MPO stays small at this length
+    H = FiniteMPOHamiltonian(fill(pspace, L), (i, i + 1) => nn for i in 1:(L - 1))
+
+    O = MPSKit.DenseMPO(H)
+    O′ = changebonds(O, SvdCut(; trunc = trunctol(; rtol = 1.0e-12)))
+
+    @test all(i -> dim(left_virtualspace(O′, i)) > 0, 1:L)
+    @test maxbond(O′) == maxbond(O)
+
+    ψ = FiniteMPS(rand, ComplexF64, L, pspace, ℙ^4)
+    @test expectation_value(ψ, O′) ≈ expectation_value(ψ, O) rtol = 1.0e-12
+end
+
+# Regression: `changebonds(::FiniteMPOHamiltonian, ::SvdCut)` threw a `BoundsError` for any
+# Hamiltonian with long-range terms — a star geometry leaves entirely zero rows/columns in the
+# Jordan `B`/`C` blocks, and adding such a `SparseBlockTensorMap` into a dense `BlockTensorMap`
+# tripped over the structurally absent entries.
+@testset "SvdCut on long-range FiniteMPOHamiltonian" begin
+    Random.seed!(4321)
+    pspace = ℙ^2
+    L = 8
+    nn = rand(ComplexF64, pspace * pspace, pspace * pspace)
+    nn += nn'
+    # every site couples to a single centre site, so all channels are proportional and compressible
+    centre = L ÷ 2
+    H = FiniteMPOHamiltonian(
+        fill(pspace, L), (min(i, centre), max(i, centre)) => nn for i in 1:L if i != centre
+    )
+
+    H′ = changebonds(H, SvdCut(; trunc = trunctol(; rtol = 1.0e-12)))
+    @test maxbond(H′) < maxbond(H)
+
+    ψ = FiniteMPS(rand, ComplexF64, L, pspace, ℙ^4)
+    @test expectation_value(ψ, H′) ≈ expectation_value(ψ, H) rtol = 1.0e-10
+end


### PR DESCRIPTION
## Description

MPO compression on large chains had several issues related to how the norm of these operators behaves. For MPO's this is multiplicative so can overflow, and apparently for Hamiltonians several issues were just not tested. I've bypassed some upstream issue for `add` in BlockTensorKit, and addressed the other ones mostly by properly normalizing in the best way I could see fit.

## Checklist

- [x] Tests pass locally (`julia --project=test test/runtests.jl`, or the relevant subset)
- [x] Documentation updated, if this PR changes public API (docstrings, `docs/src/`)
- [x] Runic formatter is run
- [x] Changelog entry added under `[Unreleased]` in `docs/src/changelog.md`, if this PR is user-facing (new feature, behavior change, bug fix, deprecation, or removal)

Reported by @rittermarc 
